### PR TITLE
COMP: Correct warning due to locally defined symbol

### DIFF
--- a/src/VariationalRegistrationMain.cxx
+++ b/src/VariationalRegistrationMain.cxx
@@ -44,6 +44,7 @@
 // System includes:
 #include <iostream>
 #include <string>
+#define GETOPT_API
 extern "C"
 {
 #include "getopt.h"


### PR DESCRIPTION
On Windows, the following warning was given:

warning LNK4217: locally defined symbol getopt imported in function main