### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkContinuousBorderWarpImageFilter.h
+++ b/include/itkContinuousBorderWarpImageFilter.h
@@ -64,6 +64,8 @@ class ContinuousBorderWarpImageFilter :
     public WarpImageFilter<TInputImage, TOutputImage, TDisplacementField>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ContinuousBorderWarpImageFilter);
+
   /** Standard class type alias. */
   using Self = ContinuousBorderWarpImageFilter;
   using Superclass = WarpImageFilter<TInputImage,TOutputImage, TDisplacementField>;
@@ -115,11 +117,6 @@ protected:
    * ThreadedGenerateData(). */
   void ThreadedGenerateData(const OutputImageRegionType& outputRegionForThread,
       ThreadIdType threadId ) override;
-
-private:
-  ContinuousBorderWarpImageFilter(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
 };
 
 } // end namespace itk

--- a/include/itkVariationalDiffeomorphicRegistrationFilter.h
+++ b/include/itkVariationalDiffeomorphicRegistrationFilter.h
@@ -81,6 +81,8 @@ class VariationalDiffeomorphicRegistrationFilter
   : public VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalDiffeomorphicRegistrationFilter);
+
   /** Standard class type alias */
   using Self = VariationalDiffeomorphicRegistrationFilter;
   using Superclass = VariationalRegistrationFilter<
@@ -173,9 +175,6 @@ protected:
     { return m_Exponentiator; }
 
 private:
-  VariationalDiffeomorphicRegistrationFilter(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   /** The deformation field. */
   FieldExponentiatorPointer m_Exponentiator;
   DisplacementFieldPointer  m_DisplacementField;

--- a/include/itkVariationalRegistrationCurvatureRegularizer.h
+++ b/include/itkVariationalRegistrationCurvatureRegularizer.h
@@ -63,6 +63,8 @@ class VariationalRegistrationCurvatureRegularizer
   : public VariationalRegistrationRegularizer< TDisplacementField >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalRegistrationCurvatureRegularizer);
+
   /** Standard class type alias */
   using Self = VariationalRegistrationCurvatureRegularizer;
   using Superclass = VariationalRegistrationRegularizer<TDisplacementField >;
@@ -143,9 +145,6 @@ protected:
       OffsetValueType offset );
 
 private:
-  VariationalRegistrationCurvatureRegularizer(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   /** Weight of the regularization term. */
   ValueType m_Alpha;
 

--- a/include/itkVariationalRegistrationDemonsFunction.h
+++ b/include/itkVariationalRegistrationDemonsFunction.h
@@ -56,6 +56,8 @@ class VariationalRegistrationDemonsFunction :
     public VariationalRegistrationFunction< TFixedImage, TMovingImage, TDisplacementField >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalRegistrationDemonsFunction);
+
   /** Standard class type alias. */
   using Self = VariationalRegistrationDemonsFunction;
   using Superclass = VariationalRegistrationFunction<
@@ -158,9 +160,6 @@ protected:
   };
 
 private:
-  VariationalRegistrationDemonsFunction(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   /** Function to compute derivatives of the fixed image. */
   GradientCalculatorPointer       m_FixedImageGradientCalculator;
 

--- a/include/itkVariationalRegistrationDiffusionRegularizer.h
+++ b/include/itkVariationalRegistrationDiffusionRegularizer.h
@@ -52,6 +52,8 @@ class VariationalRegistrationDiffusionRegularizer
   : public VariationalRegistrationRegularizer< TDisplacementField >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalRegistrationDiffusionRegularizer);
+
   /** Standard class type alias */
   using Self = VariationalRegistrationDiffusionRegularizer;
   using Superclass = VariationalRegistrationRegularizer<
@@ -156,9 +158,6 @@ protected:
       BufferImageRegionType& splitRegion );
 
 private:
-  VariationalRegistrationDiffusionRegularizer(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   /** Weight of the regularization term. */
   ValueType m_Alpha;
 

--- a/include/itkVariationalRegistrationElasticRegularizer.h
+++ b/include/itkVariationalRegistrationElasticRegularizer.h
@@ -59,6 +59,8 @@ class VariationalRegistrationElasticRegularizer
   : public VariationalRegistrationRegularizer< TDisplacementField >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalRegistrationElasticRegularizer);
+
   /** Standard class type alias */
   using Self = VariationalRegistrationElasticRegularizer;
   using Superclass = VariationalRegistrationRegularizer<
@@ -149,9 +151,6 @@ protected:
       OffsetValueType offset );
 
 private:
-  VariationalRegistrationElasticRegularizer(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   /** Weight of the regularization term. */
   ValueType m_Lambda;
 

--- a/include/itkVariationalRegistrationFastNCCFunction.h
+++ b/include/itkVariationalRegistrationFastNCCFunction.h
@@ -65,6 +65,8 @@ class VariationalRegistrationFastNCCFunction :
   public VariationalRegistrationNCCFunction< TFixedImage,  TMovingImage, TDisplacementField >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalRegistrationFastNCCFunction);
+
   /** Standard class type alias. */
   using Self = VariationalRegistrationFastNCCFunction;
   using Superclass = VariationalRegistrationNCCFunction< TFixedImage,  TMovingImage, TDisplacementField >;
@@ -155,10 +157,6 @@ protected:
     double smmLastValue;
     double sfmLastValue;
     };
-
-private:
-  VariationalRegistrationFastNCCFunction(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
 };
 
 

--- a/include/itkVariationalRegistrationFilter.h
+++ b/include/itkVariationalRegistrationFilter.h
@@ -103,6 +103,8 @@ class VariationalRegistrationFilter
   : public DenseFiniteDifferenceImageFilter< TDisplacementField, TDisplacementField >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalRegistrationFilter);
+
   /** Standard class type alias */
   using Self = VariationalRegistrationFilter;
   using Superclass = DenseFiniteDifferenceImageFilter<
@@ -289,9 +291,6 @@ protected:
   const RegistrationFunctionType * DownCastDifferenceFunctionType() const;
 
 private:
-  VariationalRegistrationFilter(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   /** Regularizer for the smoothing of the displacement field. */
   RegularizerPointer m_Regularizer;
 

--- a/include/itkVariationalRegistrationFunction.h
+++ b/include/itkVariationalRegistrationFunction.h
@@ -51,6 +51,8 @@ class VariationalRegistrationFunction :
   public FiniteDifferenceFunction< TDisplacementField >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalRegistrationFunction);
+
   /** Standard class type alias. */
   using Self = VariationalRegistrationFunction;
   using Superclass = FiniteDifferenceFunction< TDisplacementField >;
@@ -203,9 +205,6 @@ protected:
     };
 
 private:
-  VariationalRegistrationFunction(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   /** The Moving image. */
   MovingImagePointer              m_MovingImage;
 

--- a/include/itkVariationalRegistrationGaussianRegularizer.h
+++ b/include/itkVariationalRegistrationGaussianRegularizer.h
@@ -47,6 +47,8 @@ class VariationalRegistrationGaussianRegularizer
   : public VariationalRegistrationRegularizer< TDisplacementField >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalRegistrationGaussianRegularizer);
+
   /** Standard class type alias */
   using Self = VariationalRegistrationGaussianRegularizer;
   using Superclass = VariationalRegistrationRegularizer<
@@ -121,9 +123,6 @@ protected:
   void Initialize() override;
 
 private:
-  VariationalRegistrationGaussianRegularizer(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   /** Standard deviation for Gaussian smoothing */
   StandardDeviationsType m_StandardDeviations;
 

--- a/include/itkVariationalRegistrationLogger.h
+++ b/include/itkVariationalRegistrationLogger.h
@@ -47,6 +47,8 @@ class VariationalRegistrationLogger
   : public Command
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalRegistrationLogger);
+
   /** Standard class type alias. */
   using Self = VariationalRegistrationLogger;
   using Superclass = Command;
@@ -75,10 +77,6 @@ protected:
 
   /** Print information about the filter. */
   void PrintSelf(std::ostream& os, Indent indent) const override;
-
-private:
-  VariationalRegistrationLogger(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
 };
 
 } // end namespace itk

--- a/include/itkVariationalRegistrationMultiResolutionFilter.h
+++ b/include/itkVariationalRegistrationMultiResolutionFilter.h
@@ -82,6 +82,8 @@ class VariationalRegistrationMultiResolutionFilter :
     public ImageToImageFilter< TDisplacementField, TDisplacementField >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalRegistrationMultiResolutionFilter);
+
   /** Standard class type alias */
   using Self = VariationalRegistrationMultiResolutionFilter;
   using Superclass = ImageToImageFilter< TDisplacementField, TDisplacementField >;
@@ -277,9 +279,6 @@ protected:
   virtual bool Halt();
 
 private:
-  VariationalRegistrationMultiResolutionFilter(const Self&); //purposely not implemented
-  void operator=( const Self& ); //purposely not implemented
-
   RegistrationPointer        m_RegistrationFilter;
   FixedImagePyramidPointer   m_FixedImagePyramid;
   MovingImagePyramidPointer  m_MovingImagePyramid;

--- a/include/itkVariationalRegistrationNCCFunction.h
+++ b/include/itkVariationalRegistrationNCCFunction.h
@@ -65,6 +65,8 @@ class VariationalRegistrationNCCFunction :
   public VariationalRegistrationFunction< TFixedImage,  TMovingImage, TDisplacementField >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalRegistrationNCCFunction);
+
   /** Standard class type alias. */
   using Self = VariationalRegistrationNCCFunction;
   using Superclass = VariationalRegistrationFunction< TFixedImage,  TMovingImage, TDisplacementField >;
@@ -168,10 +170,6 @@ protected:
 
   /** Precalculated normalizer for spacing consideration. */
   double                          m_Normalizer;
-
-private:
-  VariationalRegistrationNCCFunction(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
 };
 
 

--- a/include/itkVariationalRegistrationRegularizer.h
+++ b/include/itkVariationalRegistrationRegularizer.h
@@ -48,6 +48,8 @@ class VariationalRegistrationRegularizer
   : public InPlaceImageFilter< TDisplacementField, TDisplacementField >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalRegistrationRegularizer);
+
   /** Standard class type alias */
   using Self = VariationalRegistrationRegularizer;
   using Superclass = InPlaceImageFilter<
@@ -91,9 +93,6 @@ protected:
   virtual void Initialize() {};
 
 private:
-  VariationalRegistrationRegularizer(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   /** A boolean that indicates, if image spacing is considered. */
   bool m_UseImageSpacing;
 };

--- a/include/itkVariationalRegistrationSSDFunction.h
+++ b/include/itkVariationalRegistrationSSDFunction.h
@@ -49,10 +49,12 @@ namespace itk {
  *  \author Jan Ehrhardt
  */
 template< class TFixedImage, class TMovingImage, class TDisplacementField >
-class VariationalRegistrationSSDFunction :
+class  :
     public VariationalRegistrationFunction< TFixedImage, TMovingImage, TDisplacementField >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalRegistrationSSDFunction);
+
   /** Standard class type alias. */
   using Self = VariationalRegistrationSSDFunction;
   using Superclass = VariationalRegistrationFunction< TFixedImage, TMovingImage, TDisplacementField >;
@@ -159,9 +161,6 @@ protected:
   };
 
 private:
-  VariationalRegistrationSSDFunction(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   /** Function to compute derivatives of the fixed image. */
   GradientCalculatorPointer       m_FixedImageGradientCalculator;
 

--- a/include/itkVariationalRegistrationStopCriterion.h
+++ b/include/itkVariationalRegistrationStopCriterion.h
@@ -69,6 +69,8 @@ class VariationalRegistrationStopCriterion
   : public Command
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalRegistrationStopCriterion);
+
   /** Standard class type alias. */
   using Self = VariationalRegistrationStopCriterion;
   using Superclass = Command;
@@ -244,9 +246,6 @@ protected:
       const int n, double *m, double *b);
 
 private:
-  VariationalRegistrationStopCriterion(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   // Stop criterion multi-resolution policy.
   MultiResolutionPolicy m_MultiResolutionPolicy;
 

--- a/include/itkVariationalSymmetricDiffeomorphicRegistrationFilter.h
+++ b/include/itkVariationalSymmetricDiffeomorphicRegistrationFilter.h
@@ -91,6 +91,8 @@ class VariationalSymmetricDiffeomorphicRegistrationFilter
   : public VariationalDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalSymmetricDiffeomorphicRegistrationFilter);
+
   /** Standard class type alias */
   using Self = VariationalSymmetricDiffeomorphicRegistrationFilter;
   using Superclass = VariationalDiffeomorphicRegistrationFilter<
@@ -175,9 +177,6 @@ protected:
                                     unsigned int threadId ) override;
 
 private:
-  VariationalSymmetricDiffeomorphicRegistrationFilter( const Self& ); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   using FieldExponentiatorType = typename Superclass::FieldExponentiatorType;
   using FieldExponentiatorPointer = typename FieldExponentiatorType::Pointer;
 


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.