### PR TITLE
BUG: Fix CMake errors.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,10 @@
+cmake_minimum_required(VERSION 3.10.2)
 project(VariationalRegistration)
-enable_testing()
-itk_module_impl()
+
+if(NOT ITK_SOURCE_DIR)
+  find_package(ITK REQUIRED)
+  list(APPEND CMAKE_MODULE_PATH ${ITK_CMAKE_DIR})
+  include(ITKModuleExternal)
+else()
+  itk_module_impl()
+endif()


### PR DESCRIPTION
Fix the `CMakeLists.txt` file to allow building the module as a standalone
module.

Addresses the following CMake configuration error:
```
CMake Error at CMakeLists.txt:3 (itk_module_impl):
Unknown CMake command "itk_module_impl".

CMake Warning (dev) in CMakeLists.txt:
No cmake_minimum_required command is present.  A line of code such as

cmake_minimum_required(VERSION 3.10)

should be added at the top of the file.  The version specified may be
lower
if you wish to support older CMake versions for this project.  For more
information run "cmake --help-policy CMP0000".
This warning is for project developers.  Use -Wno-dev to suppress it.
```