### PR TITLE
ENH: Adapt to new multi-threading naming convention.

### DIFF
--- a/include/itkVariationalRegistrationCurvatureRegularizer.hxx
+++ b/include/itkVariationalRegistrationCurvatureRegularizer.hxx
@@ -198,7 +198,7 @@ bool VariationalRegistrationCurvatureRegularizer<TDisplacementField>::Initialize
   // directly
 
   // first set multi-threading
-  fftw_plan_with_nthreads( this->GetNumberOfThreads() );
+  fftw_plan_with_nthreads( this->GetNumberOfWorkUnits() );
 
   this->m_PlanForward = fftw_plan_r2r( ImageDimension, size, this->m_VectorFieldComponentBuffer, this->m_DCTVectorFieldComponentBuffer, fftForwardKind, FFTW_MEASURE | FFTW_DESTROY_INPUT );
   if( this->m_PlanForward == nullptr )
@@ -351,7 +351,7 @@ void VariationalRegistrationCurvatureRegularizer<TDisplacementField>::SolveCurva
   curvatureThreadParameters.currentDimension = currentDimension;
 
   // Setup MultiThreader
-  this->GetMultiThreader()->SetNumberOfThreads( this->GetNumberOfThreads() );
+  this->GetMultiThreader()->SetNumberOfWorkUnits( this->GetNumberOfWorkUnits() );
   this->GetMultiThreader()->SetSingleMethod( this->SolveCurvatureLESThreaderCallback, &curvatureThreadParameters );
 
   // Execute MultiThreader
@@ -365,9 +365,9 @@ template<class TDisplacementField>
 ITK_THREAD_RETURN_TYPE VariationalRegistrationCurvatureRegularizer<TDisplacementField>::SolveCurvatureLESThreaderCallback( void * arg )
 {
   //Get MultiThreader struct
-  auto* threadStruct = (MultiThreader::ThreadInfoStruct *) arg;
-  int threadId = threadStruct->ThreadID;
-  int threadCount = threadStruct->NumberOfThreads;
+  auto* threadStruct = (MultiThreaderBase::WorkUnitInfo *) arg;
+  int threadId = threadStruct->WorkUnitID;
+  int threadCount = threadStruct->NumberOfWorkUnits;
 
   // Calculate region for current thread
   auto* userStruct = (CurvatureFFTThreadStruct*) threadStruct->UserData;

--- a/include/itkVariationalRegistrationDiffusionRegularizer.hxx
+++ b/include/itkVariationalRegistrationDiffusionRegularizer.hxx
@@ -180,7 +180,7 @@ VariationalRegistrationDiffusionRegularizer< TDisplacementField >
   calcBufferStr.component = component;
   calcBufferStr.bPtr = m_BufferImage;
 
-  this->GetMultiThreader()->SetNumberOfThreads( this->GetNumberOfThreads() );
+  this->GetMultiThreader()->SetNumberOfWorkUnits( this->GetNumberOfWorkUnits() );
   this->GetMultiThreader()->SetSingleMethod( this->CalcBufferCallback, &calcBufferStr );
 
   // Multithread the execution
@@ -234,9 +234,9 @@ VariationalRegistrationDiffusionRegularizer< TDisplacementField >
 ::CalcBufferCallback( void* arg )
 {
   // Get MultiThreader struct
-  auto* threadStruct = (MultiThreader::ThreadInfoStruct *) arg;
-  int threadId = threadStruct->ThreadID;
-  int threadCount = threadStruct->NumberOfThreads;
+  auto* threadStruct = (MultiThreaderBase::WorkUnitInfo *) arg;
+  int threadId = threadStruct->WorkUnitID;
+  int threadCount = threadStruct->NumberOfWorkUnits;
 
   // Get user struct
   auto* userStruct = (CalcBufferThreadStruct*) threadStruct->UserData;
@@ -281,9 +281,9 @@ VariationalRegistrationDiffusionRegularizer< TDisplacementField >
 ::RegularizeDirectionCallback( void* arg )
 {
   // Get MultiThreader struct
-  auto* threadStruct = (MultiThreader::ThreadInfoStruct *) (arg);
-  int threadId = threadStruct->ThreadID;
-  int threadCount = threadStruct->NumberOfThreads;
+  auto* threadStruct = (MultiThreaderBase::WorkUnitInfo *) (arg);
+  int threadId = threadStruct->WorkUnitID;
+  int threadCount = threadStruct->NumberOfWorkUnits;
 
   // Get user struct
   auto* userStruct = (RegularizeThreadStruct*) threadStruct->UserData;
@@ -372,9 +372,9 @@ VariationalRegistrationDiffusionRegularizer< TDisplacementField >
 ::MergeDirectionsCallback( void* arg )
 {
   // Get MultiThreader struct
-  auto* threadStruct = (MultiThreader::ThreadInfoStruct *) (arg);
-  int threadId = threadStruct->ThreadID;
-  int threadCount = threadStruct->NumberOfThreads;
+  auto* threadStruct = (MultiThreaderBase::WorkUnitInfo *) (arg);
+  int threadId = threadStruct->WorkUnitID;
+  int threadCount = threadStruct->NumberOfWorkUnits;
 
   // Get user struct
   auto* userStruct = (MergeDirectionsThreadStruct*) threadStruct->UserData;

--- a/include/itkVariationalRegistrationElasticRegularizer.hxx
+++ b/include/itkVariationalRegistrationElasticRegularizer.hxx
@@ -207,14 +207,14 @@ VariationalRegistrationElasticRegularizer< TDisplacementField >
         this->m_InputBuffer,
         this->m_ComplexBuffer[i],
         FFTW_MEASURE,
-        this->GetNumberOfThreads() );
+        this->GetNumberOfWorkUnits() );
 
     this->m_PlanBackward[i] = FFTWProxyType::Plan_dft_c2r(
         ImageDimension, n,
         this->m_ComplexBuffer[i],
         this->m_OutputBuffer,
         FFTW_MEASURE,
-        this->GetNumberOfThreads() );
+        this->GetNumberOfWorkUnits() );
     }
 
   //delete n
@@ -328,7 +328,7 @@ VariationalRegistrationElasticRegularizer< TDisplacementField >
   elasticLESStr.totalComplexSize = this->m_TotalComplexSize;
 
   // Setup MultiThreader
-  this->GetMultiThreader()->SetNumberOfThreads( this->GetNumberOfThreads() );
+  this->GetMultiThreader()->SetNumberOfWorkUnits( this->GetNumberOfWorkUnits() );
   this->GetMultiThreader()->SetSingleMethod(
       this->SolveElasticLESThreaderCallback, &elasticLESStr );
 
@@ -345,9 +345,9 @@ VariationalRegistrationElasticRegularizer< TDisplacementField >
 ::SolveElasticLESThreaderCallback( void * arg )
 {
   //Get MultiThreader struct
-  auto* threadStruct = (MultiThreader::ThreadInfoStruct *) arg;
-  int threadId = threadStruct->ThreadID;
-  int threadCount = threadStruct->NumberOfThreads;
+  auto* threadStruct = (MultiThreaderBase::WorkUnitInfo *) arg;
+  int threadId = threadStruct->WorkUnitID;
+  int threadCount = threadStruct->NumberOfWorkUnits;
 
   // Calculate region for current thread
   auto* userStruct = (ElasticFFTThreadStruct*) threadStruct->UserData;


### PR DESCRIPTION
Adapt to new multi-threading naming convention. Specifically:
- Change `MultiThreader::ThreadInfoStruct` to
  `MultiThreaderBase::WorkUnitInfo`
- Change `(threadInfo)->ThreadID` to `(threadInfo)->WorkUnitID`
- Change `(threadInfo)->NumberOfThreads` to
  `(threadInfo)->NumberOfWorkUnits`

after commit:
https://github.com/InsightSoftwareConsortium/ITK/commit/ce15429a230a82617af1e19fd9a6964e9fc65d1d

Addresses deprecation warnings:
```
itkvariationalregistration\include\itkVariationalRegistrationDiffusionRegularizer.hxx(238):
warning C4996: 'itk::MultiThreaderBase::ThreadInfoStruct': Use
WorkUnitInfo, ThreadInfoStruct is deprecated since ITK 5.0
```