### PR TITLE
DOC: Improve documentation.

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,0 @@
-This is a module designed to work with the ITK v4 modular system; it implements a collection of classes for performing variational image registration.
-
-The module should be placed in [ITK_root]/Modules/External/. You should then configure and compile ITK as normal.
-
-Select the option Module_VariationalRegistration to compile this project. To do this you may have to toggle advanced mode on CMake.

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,31 @@
+ITKVariationalRegistration
+==========================
+
+Overview
+--------
+
+This is a module for the `Insight Toolkit (ITK) <http://itk.org>`_ that
+provides a fexible framework for deformable registration of two images using
+PDE-based variational registration.
+
+For more information, see the `Insight Journal article <http://hdl.handle.net/10380/3460>`_::
+
+   Schmidt-Richberg A., Werner R., Handels H., Ehrhardt J.
+   A Flexible Variational Registration Framework
+   The Insight Journal. January-December. 2014.
+   http://hdl.handle.net/10380/3460
+   http://www.insight-journal.org/browse/publication/917
+
+This work was motivated by the following publication:
+
+   Rene Werner, Alexander Schmidt-Richberg, Heinz Handels and Jan Ehrhardt:
+   Estimation of lung motion fields in 4D CT data by variational non-linear
+   intensity-based registration: A comparison and evaluation study,
+   Phys. Med. Biol., 2014
+
+
+Acknowledgements
+----------------
+
+This work was supported with by the German Research Foundation (DFG: EH 224/3-1
+and HA 235/9-1).

--- a/include/itkVariationalRegistrationFilter.h
+++ b/include/itkVariationalRegistrationFilter.h
@@ -54,7 +54,7 @@ namespace itk {
  *  Different force terms and regularization methods can be combined by using the methods SetDifferenceFunction() and
  *  SetRegularizer().
  *
- *  The implemented method can be summariced as follows:
+ *  The implemented method can be summarized as follows:
  *    - initialize \f$ u \f$ (default \f$ u=0 \f$)
  *    - <b>do</b>
  *      - compute the update field \f$ f^k \f$ using \f$ R(x) \f$ and the warped image \f$ T(x+u^k(x)) \f$

--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -1,32 +1,29 @@
-set(DOCUMENTATION "This module contains a collection of classes for performing
-   variational image registration. See VariationalRegistrationFilter for a
-   brief introduction. For further information on the algorithm, please refer to:
-   
-   Rene Werner, Alexander Schmidt-Richberg, Heinz Handels and Jan Ehrhardt:
-   Estimation of lung motion fields in 4D CT data by variational non-linear
-   intensity-based registration: A comparison and evaluation study,
-   Phys. Med. Biol., 2014
-   
-   Information on the implementation can be found in:
-   
-   Alexander Schmidt-Richberg, Rene Werner, Heinz Handels and Jan Ehrhardt:
-   A Flexible Variational Registration Framework, Insight Journal, 2014
-   http://hdl.handle.net/10380/3460"
-  )
+# the top-level README is used for describing this module, just
+# re-used it for documentation here
+get_filename_component(MY_CURRENT_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+file(READ "${MY_CURRENT_DIR}/README.rst" DOCUMENTATION)
 
+# itk_module() defines the module dependencies in VariationalRegistration
+# The testing module in VariationalRegistration depends on ITKTestKernel
+# By convention those modules outside of ITK are not prefixed with
+# ITK.
+
+# define the dependencies of the include module and the tests
 itk_module(VariationalRegistration
- DEPENDS
-   ITKCommon
-   ITKIOImageBase
-   ITKImageFilterBase
-   ITKSmoothing
-   ITKFFT
-   ITKFiniteDifference
-   ITKDisplacementField
-   ITKRegistrationCommon
-   ITKMathematicalMorphology
-   ITKBinaryMathematicalMorphology
-   ITKTestKernel #necessary to handle IO in src
+  DEPENDS
+    ITKCommon
+    ITKIOImageBase
+    ITKImageFilterBase
+    ITKSmoothing
+    ITKFFT
+    ITKFiniteDifference
+    ITKDisplacementField
+    ITKRegistrationCommon
+    ITKMathematicalMorphology
+    ITKBinaryMathematicalMorphology
+    ITKTestKernel #necessary to handle IO in src
+  TEST_DEPENDS
+    ITKTestKernel
  EXCLUDE_FROM_DEFAULT
  DESCRIPTION
    "${DOCUMENTATION}"


### PR DESCRIPTION
Improve the module documentation. Specifically:
- Use the **.rst** file format for the `README` fie to conform to the
  `ITKModuleTemplate` directions.
- Improve the documentation in the `README.rst` file.
- Re-use the `README.rst` file documentation in the `itk-module.cmake`
  file.
- Fix a typo in the `itkVariationalRegistrationFilter.h` file.