### PR TITLE
STYLE: Use "typename" for template parameters.

### DIFF
--- a/include/itkContinuousBorderWarpImageFilter.h
+++ b/include/itkContinuousBorderWarpImageFilter.h
@@ -56,9 +56,9 @@ namespace itk
  *  \author Jan Ehrhardt
  */
 template <
-  class TInputImage,
-  class TOutputImage,
-  class TDisplacementField
+  typename TInputImage,
+  typename TOutputImage,
+  typename TDisplacementField
   >
 class ContinuousBorderWarpImageFilter :
     public WarpImageFilter<TInputImage, TOutputImage, TDisplacementField>

--- a/include/itkContinuousBorderWarpImageFilter.hxx
+++ b/include/itkContinuousBorderWarpImageFilter.hxx
@@ -26,7 +26,7 @@ namespace itk
 /**
  * Compute the output for the region specified by outputRegionForThread.
  */
-template<class TInputImage, class TOutputImage, class TDisplacementField>
+template<typename TInputImage, typename TOutputImage, typename TDisplacementField>
 void ContinuousBorderWarpImageFilter<TInputImage, TOutputImage, TDisplacementField>
 ::ThreadedGenerateData( const OutputImageRegionType& outputRegionForThread, ThreadIdType threadId )
 {

--- a/include/itkVariationalDiffeomorphicRegistrationFilter.h
+++ b/include/itkVariationalDiffeomorphicRegistrationFilter.h
@@ -76,7 +76,7 @@ namespace itk {
  *      <i>Statistical modeling of 4D respiratory lung motion using diffeomorphic
  *      image registration.</i> IEEE Trans. Med. Imaging, 30(2), 2011
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField>
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 class VariationalDiffeomorphicRegistrationFilter
   : public VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 {

--- a/include/itkVariationalDiffeomorphicRegistrationFilter.hxx
+++ b/include/itkVariationalDiffeomorphicRegistrationFilter.hxx
@@ -28,7 +28,7 @@ namespace itk
 /**
  * Default constructor
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 VariationalDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::VariationalDiffeomorphicRegistrationFilter()
 {
@@ -42,7 +42,7 @@ VariationalDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, TDisplace
 /*
  * Set the mask image.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::SetInitialDisplacementField( DisplacementFieldType * /*ptr*/ )
@@ -57,7 +57,7 @@ VariationalDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, TDisplace
 /*
  * Initialize flags
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::Initialize()
@@ -99,7 +99,7 @@ VariationalDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, TDisplace
 /**
  * Get the metric value from the difference function
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::ApplyUpdate( const TimeStepType& dt )
@@ -116,7 +116,7 @@ VariationalDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, TDisplace
  * Calculates the deformation field by calculating the exponential
  * of the velocity field
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::CalcDeformationFromVelocityField( const DisplacementFieldType * velocityField )
@@ -136,7 +136,7 @@ VariationalDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, TDisplace
 /*
  * Print status information
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::PrintSelf( std::ostream& os, Indent indent ) const

--- a/include/itkVariationalRegistrationCurvatureRegularizer.h
+++ b/include/itkVariationalRegistrationCurvatureRegularizer.h
@@ -58,7 +58,7 @@ namespace itk {
  *  \author Rene Werner
  *  \author Jan Ehrhardt
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 class VariationalRegistrationCurvatureRegularizer
   : public VariationalRegistrationRegularizer< TDisplacementField >
 {

--- a/include/itkVariationalRegistrationCurvatureRegularizer.hxx
+++ b/include/itkVariationalRegistrationCurvatureRegularizer.hxx
@@ -32,7 +32,7 @@ namespace itk
 /**
  * Default constructor
  */
-template<class TDisplacementField>
+template<typename TDisplacementField>
 VariationalRegistrationCurvatureRegularizer<TDisplacementField>::VariationalRegistrationCurvatureRegularizer()
 {
   for( unsigned int i = 0; i < ImageDimension; ++i )
@@ -60,7 +60,7 @@ VariationalRegistrationCurvatureRegularizer<TDisplacementField>::VariationalRegi
 /**
  * Default destructor
  */
-template<class TDisplacementField>
+template<typename TDisplacementField>
 VariationalRegistrationCurvatureRegularizer<TDisplacementField>::~VariationalRegistrationCurvatureRegularizer()
 {
   //
@@ -90,7 +90,7 @@ VariationalRegistrationCurvatureRegularizer<TDisplacementField>::~VariationalReg
 /**
  * Generate data
  */
-template<class TDisplacementField>
+template<typename TDisplacementField>
 void VariationalRegistrationCurvatureRegularizer<TDisplacementField>::GenerateData()
 {
   // Allocate the output image
@@ -106,7 +106,7 @@ void VariationalRegistrationCurvatureRegularizer<TDisplacementField>::GenerateDa
 /*
  * Initialize flags
  */
-template<class TDisplacementField>
+template<typename TDisplacementField>
 void VariationalRegistrationCurvatureRegularizer<TDisplacementField>::Initialize()
 {
   this->Superclass::Initialize();
@@ -152,7 +152,7 @@ void VariationalRegistrationCurvatureRegularizer<TDisplacementField>::Initialize
 /**
  * Initialize FFT plans
  */
-template<class TDisplacementField>
+template<typename TDisplacementField>
 bool VariationalRegistrationCurvatureRegularizer<TDisplacementField>::InitializeCurvatureFFTPlans()
 {
   itkDebugMacro( << "Initializing curvature plans for FFT..." );
@@ -218,7 +218,7 @@ bool VariationalRegistrationCurvatureRegularizer<TDisplacementField>::Initialize
 /**
  * Initialize elastic matrix
  */
-template<class TDisplacementField>
+template<typename TDisplacementField>
 bool VariationalRegistrationCurvatureRegularizer<TDisplacementField>::InitializeCurvatureDiagonalMatrix()
 {
   itkDebugMacro( << "Initializing curvature matrix for FFT..." );
@@ -262,7 +262,7 @@ bool VariationalRegistrationCurvatureRegularizer<TDisplacementField>::Initialize
 /**
  * Execute regularization
  */
-template<class TDisplacementField>
+template<typename TDisplacementField>
 void VariationalRegistrationCurvatureRegularizer<TDisplacementField>::Regularize()
 {
   DisplacementFieldConstPointer inputField = this->GetInput();
@@ -341,7 +341,7 @@ void VariationalRegistrationCurvatureRegularizer<TDisplacementField>::Regularize
 /**
  * Solve elastic LES
  */
-template<class TDisplacementField>
+template<typename TDisplacementField>
 void VariationalRegistrationCurvatureRegularizer<TDisplacementField>::SolveCurvatureLES( unsigned int currentDimension )
 {
   // Declare thread data struct and set filter
@@ -361,7 +361,7 @@ void VariationalRegistrationCurvatureRegularizer<TDisplacementField>::SolveCurva
 /**
  * Solve elastic LES
  */
-template<class TDisplacementField>
+template<typename TDisplacementField>
 ITK_THREAD_RETURN_TYPE VariationalRegistrationCurvatureRegularizer<TDisplacementField>::SolveCurvatureLESThreaderCallback( void * arg )
 {
   //Get MultiThreader struct
@@ -386,7 +386,7 @@ ITK_THREAD_RETURN_TYPE VariationalRegistrationCurvatureRegularizer<TDisplacement
 /**
  * Solve elastic LES
  */
-template<class TDisplacementField>
+template<typename TDisplacementField>
 void VariationalRegistrationCurvatureRegularizer<TDisplacementField>::ThreadedSolveCurvatureLES( unsigned int currentDimension, OffsetValueType from, OffsetValueType to )
 {
 
@@ -441,7 +441,7 @@ void VariationalRegistrationCurvatureRegularizer<TDisplacementField>::ThreadedSo
 /*
  * Calculate the index in the complex image for a given offset.
  */
-template<class TDisplacementField>
+template<typename TDisplacementField>
 typename VariationalRegistrationCurvatureRegularizer<TDisplacementField>::DisplacementFieldType::IndexType VariationalRegistrationCurvatureRegularizer<TDisplacementField>
 ::CalculateImageIndex( OffsetValueType offset )
 {
@@ -462,7 +462,7 @@ typename VariationalRegistrationCurvatureRegularizer<TDisplacementField>::Displa
 /*
  * Print status information
  */
-template<class TDisplacementField>
+template<typename TDisplacementField>
 void VariationalRegistrationCurvatureRegularizer<TDisplacementField>::PrintSelf( std::ostream& os, Indent indent ) const
 {
   Superclass::PrintSelf( os, indent );

--- a/include/itkVariationalRegistrationDemonsFunction.h
+++ b/include/itkVariationalRegistrationDemonsFunction.h
@@ -51,7 +51,7 @@ namespace itk {
  *  \author Rene Werner
  *  \author Jan Ehrhardt
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 class VariationalRegistrationDemonsFunction :
     public VariationalRegistrationFunction< TFixedImage, TMovingImage, TDisplacementField >
 {

--- a/include/itkVariationalRegistrationDemonsFunction.hxx
+++ b/include/itkVariationalRegistrationDemonsFunction.hxx
@@ -27,7 +27,7 @@ namespace itk
 /**
  * Default constructor
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 VariationalRegistrationDemonsFunction< TFixedImage, TMovingImage, TDisplacementField >
 ::VariationalRegistrationDemonsFunction()
 {
@@ -44,7 +44,7 @@ VariationalRegistrationDemonsFunction< TFixedImage, TMovingImage, TDisplacementF
 /**
  * Standard "PrintSelf" method.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalRegistrationDemonsFunction< TFixedImage, TMovingImage, TDisplacementField >
 ::PrintSelf( std::ostream& os, Indent indent ) const
@@ -69,7 +69,7 @@ VariationalRegistrationDemonsFunction< TFixedImage, TMovingImage, TDisplacementF
 /**
  * Set the function state values before each iteration
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalRegistrationDemonsFunction< TFixedImage, TMovingImage, TDisplacementField >
 ::InitializeIteration()
@@ -97,7 +97,7 @@ VariationalRegistrationDemonsFunction< TFixedImage, TMovingImage, TDisplacementF
 /**
  * Compute update at a specific neighborhood
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 typename VariationalRegistrationDemonsFunction< TFixedImage, TMovingImage, TDisplacementField >
 ::PixelType
 VariationalRegistrationDemonsFunction< TFixedImage, TMovingImage, TDisplacementField >

--- a/include/itkVariationalRegistrationDiffusionRegularizer.h
+++ b/include/itkVariationalRegistrationDiffusionRegularizer.h
@@ -47,7 +47,7 @@ namespace itk {
  *  \author Rene Werner
  *  \author Jan Ehrhardt
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 class VariationalRegistrationDiffusionRegularizer
   : public VariationalRegistrationRegularizer< TDisplacementField >
 {

--- a/include/itkVariationalRegistrationDiffusionRegularizer.hxx
+++ b/include/itkVariationalRegistrationDiffusionRegularizer.hxx
@@ -28,7 +28,7 @@ namespace itk
 /**
  * Default constructor
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 VariationalRegistrationDiffusionRegularizer< TDisplacementField >
 ::VariationalRegistrationDiffusionRegularizer()
 {
@@ -45,7 +45,7 @@ VariationalRegistrationDiffusionRegularizer< TDisplacementField >
 /**
  * Generate data by regularizing each component of the field independently
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 void
 VariationalRegistrationDiffusionRegularizer< TDisplacementField >
 ::GenerateData()
@@ -66,7 +66,7 @@ VariationalRegistrationDiffusionRegularizer< TDisplacementField >
 /*
  * Initialize flags
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 void
 VariationalRegistrationDiffusionRegularizer< TDisplacementField >
 ::Initialize()
@@ -109,7 +109,7 @@ VariationalRegistrationDiffusionRegularizer< TDisplacementField >
 /**
  * Initialize the matrices for the LU decomposition
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 void
 VariationalRegistrationDiffusionRegularizer< TDisplacementField >
 ::InitLUMatrices( ValueType** alphaI, ValueType** betaI, ValueType** gammaI, int n, int dim )
@@ -164,7 +164,7 @@ VariationalRegistrationDiffusionRegularizer< TDisplacementField >
 /**
  * Regularize one component of the field using AOS
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 void
 VariationalRegistrationDiffusionRegularizer< TDisplacementField >
 ::RegularizeComponent( const int component )
@@ -228,7 +228,7 @@ VariationalRegistrationDiffusionRegularizer< TDisplacementField >
  * Callback function for threaded copying of one field component into the
  * image buffer as a preparation for AOS
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 ITK_THREAD_RETURN_TYPE
 VariationalRegistrationDiffusionRegularizer< TDisplacementField >
 ::CalcBufferCallback( void* arg )
@@ -275,7 +275,7 @@ VariationalRegistrationDiffusionRegularizer< TDisplacementField >
  *
  * For efficiency reasons, this method operates directly on the image buffers.
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 ITK_THREAD_RETURN_TYPE
 VariationalRegistrationDiffusionRegularizer< TDisplacementField >
 ::RegularizeDirectionCallback( void* arg )
@@ -366,7 +366,7 @@ VariationalRegistrationDiffusionRegularizer< TDisplacementField >
  * Callback function for the threaded adding of the regularization in
  * each spatial direction
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 ITK_THREAD_RETURN_TYPE
 VariationalRegistrationDiffusionRegularizer< TDisplacementField >
 ::MergeDirectionsCallback( void* arg )
@@ -422,7 +422,7 @@ VariationalRegistrationDiffusionRegularizer< TDisplacementField >
  * version because the split is performed differently for each direction of
  * regularization.
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 int
 VariationalRegistrationDiffusionRegularizer< TDisplacementField >
 ::SplitBoundaryFaceRegion(
@@ -482,7 +482,7 @@ VariationalRegistrationDiffusionRegularizer< TDisplacementField >
 /*
  * Print status information
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 void
 VariationalRegistrationDiffusionRegularizer< TDisplacementField >
 ::PrintSelf( std::ostream& os, Indent indent ) const

--- a/include/itkVariationalRegistrationElasticRegularizer.h
+++ b/include/itkVariationalRegistrationElasticRegularizer.h
@@ -54,7 +54,7 @@ namespace itk {
  *  \author Rene Werner
  *  \author Jan Ehrhardt
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 class VariationalRegistrationElasticRegularizer
   : public VariationalRegistrationRegularizer< TDisplacementField >
 {

--- a/include/itkVariationalRegistrationElasticRegularizer.hxx
+++ b/include/itkVariationalRegistrationElasticRegularizer.hxx
@@ -32,7 +32,7 @@ namespace itk
 /**
  * Default constructor
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 VariationalRegistrationElasticRegularizer< TDisplacementField >
 ::VariationalRegistrationElasticRegularizer()
 {
@@ -65,7 +65,7 @@ VariationalRegistrationElasticRegularizer< TDisplacementField >
 /**
  * Generate data
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 void
 VariationalRegistrationElasticRegularizer< TDisplacementField >
 ::GenerateData()
@@ -83,7 +83,7 @@ VariationalRegistrationElasticRegularizer< TDisplacementField >
 /*
  * Initialize flags
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 void
 VariationalRegistrationElasticRegularizer< TDisplacementField >
 ::Initialize()
@@ -147,7 +147,7 @@ VariationalRegistrationElasticRegularizer< TDisplacementField >
 /*
  * Reset data
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 void
 VariationalRegistrationElasticRegularizer< TDisplacementField >
 ::FreeData()
@@ -176,7 +176,7 @@ VariationalRegistrationElasticRegularizer< TDisplacementField >
 /**
  * Initialize FFT plans
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 bool
 VariationalRegistrationElasticRegularizer< TDisplacementField >
 ::InitializeElasticFFTPlans()
@@ -226,7 +226,7 @@ VariationalRegistrationElasticRegularizer< TDisplacementField >
 /**
  * Initialize elastic matrix
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 bool
 VariationalRegistrationElasticRegularizer< TDisplacementField >
 ::InitializeElasticMatrix()
@@ -255,7 +255,7 @@ VariationalRegistrationElasticRegularizer< TDisplacementField >
 /**
  * Execute regularization
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 void
 VariationalRegistrationElasticRegularizer< TDisplacementField >
 ::Regularize()
@@ -317,7 +317,7 @@ VariationalRegistrationElasticRegularizer< TDisplacementField >
 /**
  * Solve elastic LES
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 void
 VariationalRegistrationElasticRegularizer< TDisplacementField >
 ::SolveElasticLES()
@@ -339,7 +339,7 @@ VariationalRegistrationElasticRegularizer< TDisplacementField >
 /**
  * Solve elastic LES
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 ITK_THREAD_RETURN_TYPE
 VariationalRegistrationElasticRegularizer< TDisplacementField >
 ::SolveElasticLESThreaderCallback( void * arg )
@@ -368,7 +368,7 @@ VariationalRegistrationElasticRegularizer< TDisplacementField >
 /**
  * Solve elastic LES
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 void
 VariationalRegistrationElasticRegularizer< TDisplacementField >
 ::ThreadedSolveElasticLES( OffsetValueType from, OffsetValueType to )
@@ -633,7 +633,7 @@ VariationalRegistrationElasticRegularizer< TDisplacementField >
 /*
  * Calculate the index in the complex image for a given offset.
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 typename VariationalRegistrationElasticRegularizer< TDisplacementField >
 ::DisplacementFieldType::IndexType
 VariationalRegistrationElasticRegularizer< TDisplacementField >
@@ -659,7 +659,7 @@ VariationalRegistrationElasticRegularizer< TDisplacementField >
 /*
  * Print status information
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 void
 VariationalRegistrationElasticRegularizer< TDisplacementField >
 ::PrintSelf( std::ostream& os, Indent indent ) const

--- a/include/itkVariationalRegistrationFastNCCFunction.h
+++ b/include/itkVariationalRegistrationFastNCCFunction.h
@@ -60,7 +60,7 @@ namespace itk {
  *  \author Rene Werner
  *  \author Jan Ehrhardt
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 class VariationalRegistrationFastNCCFunction :
   public VariationalRegistrationNCCFunction< TFixedImage,  TMovingImage, TDisplacementField >
 {

--- a/include/itkVariationalRegistrationFastNCCFunction.hxx
+++ b/include/itkVariationalRegistrationFastNCCFunction.hxx
@@ -28,7 +28,7 @@ namespace itk
 /**
  * Default constructor
  */
-template<class TFixedImage, class TMovingImage, class TDisplacementField>
+template<typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 VariationalRegistrationFastNCCFunction<TFixedImage, TMovingImage, TDisplacementField>::VariationalRegistrationFastNCCFunction()
 {
 }
@@ -36,7 +36,7 @@ VariationalRegistrationFastNCCFunction<TFixedImage, TMovingImage, TDisplacementF
 /*
  * Standard "PrintSelf" method.
  */
-template<class TFixedImage, class TMovingImage, class TDisplacementField>
+template<typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void VariationalRegistrationFastNCCFunction<TFixedImage, TMovingImage, TDisplacementField>::PrintSelf( std::ostream& os, Indent indent ) const
 {
   Superclass::PrintSelf( os, indent );
@@ -45,7 +45,7 @@ void VariationalRegistrationFastNCCFunction<TFixedImage, TMovingImage, TDisplace
 /*
  * Compute update at a non boundary neighbourhood
  */
-template<class TFixedImage, class TMovingImage, class TDisplacementField>
+template<typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 typename VariationalRegistrationFastNCCFunction<TFixedImage, TMovingImage, TDisplacementField>::PixelType
 VariationalRegistrationFastNCCFunction<TFixedImage, TMovingImage, TDisplacementField>
 ::ComputeUpdate(const NeighborhoodType &it, void *gd, const FloatOffsetType& itkNotUsed(offset) )
@@ -357,7 +357,7 @@ VariationalRegistrationFastNCCFunction<TFixedImage, TMovingImage, TDisplacementF
  * Returns an empty struct that is used by the threads to include the
  * required update information for each thread.
  */
-template<class TFixedImage, class TMovingImage, class TDisplacementField>
+template<typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void*
 VariationalRegistrationFastNCCFunction<TFixedImage, TMovingImage, TDisplacementField>::GetGlobalDataPointer() const
 {
@@ -392,7 +392,7 @@ VariationalRegistrationFastNCCFunction<TFixedImage, TMovingImage, TDisplacementF
 /**
  * Update the metric and release the per-thread-global data.
  */
-template<class TFixedImage, class TMovingImage, class TDisplacementField>
+template<typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 void VariationalRegistrationFastNCCFunction<TFixedImage, TMovingImage, TDisplacementField>::ReleaseGlobalDataPointer( void *gd ) const
 {
   auto * globalData = (NCCGlobalDataStruct *) gd;

--- a/include/itkVariationalRegistrationFilter.h
+++ b/include/itkVariationalRegistrationFilter.h
@@ -98,7 +98,7 @@ namespace itk {
  *     <i>Statistical modeling of 4D respiratory lung motion using diffeomorphic
  *     image registration.</i> IEEE Trans. Med. Imaging, 30(2), 2011
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 class VariationalRegistrationFilter
   : public DenseFiniteDifferenceImageFilter< TDisplacementField, TDisplacementField >
 {

--- a/include/itkVariationalRegistrationFilter.hxx
+++ b/include/itkVariationalRegistrationFilter.hxx
@@ -28,7 +28,7 @@ namespace itk
 /**
  * Default constructor
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::VariationalRegistrationFilter()
 {
@@ -53,7 +53,7 @@ VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 /*
  * Set the fixed image.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::SetFixedImage( const FixedImageType * ptr )
@@ -64,7 +64,7 @@ VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 /*
  * Get the fixed image.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 const typename VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::FixedImageType *
 VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
@@ -77,7 +77,7 @@ VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 /*
  * Set the moving image.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::SetMovingImage( const MovingImageType * ptr )
@@ -88,7 +88,7 @@ VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 /*
  * Get the moving image.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 const typename VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::MovingImageType *
 VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
@@ -101,7 +101,7 @@ VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 /*
  * Set the mask image.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::SetMaskImage( const MaskImageType * ptr )
@@ -112,7 +112,7 @@ VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 /*
  * Get the mask image.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 const typename VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::MaskImageType *
 VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
@@ -125,7 +125,7 @@ VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 /*
  * Checks if the required inputs are set (FixedImage and MovingImage).
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 std::vector< SmartPointer< DataObject > >::size_type
 VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::GetNumberOfValidRequiredInputs() const
@@ -149,7 +149,7 @@ VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
  * Generate output information. If initial field is set, use this for
  * generation, else use the fixed image.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::GenerateOutputInformation()
@@ -182,7 +182,7 @@ VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 /*
  *
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::GenerateInputRequestedRegion()
@@ -222,7 +222,7 @@ VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
  * Override the default implementation for the case when no initial deformation
  * field is set. In this case, the output is filled with zero vectors.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::CopyInputToOutput()
@@ -258,7 +258,7 @@ VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
  * Checks whether the DifferenceFunction is of type DemonsRegistrationFunction.
  * It throws and exception, if it is not.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 typename VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::RegistrationFunctionType *
 VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
@@ -278,7 +278,7 @@ VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
  * Checks whether the DifferenceFunction is of type DemonsRegistrationFunction.
  * It throws and exception, if it is not.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 const typename VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::RegistrationFunctionType *
 VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
@@ -298,7 +298,7 @@ VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 /*
  * Get the metric value from the difference function
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 double
 VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::GetMetric() const
@@ -310,7 +310,7 @@ VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 /*
  * Initialize flags
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::Initialize()
@@ -325,7 +325,7 @@ VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 /*
  * Set the function state values before each iteration
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::InitializeIteration()
@@ -358,7 +358,7 @@ VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 /**
  * Get the metric value from the difference function
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::ApplyUpdate( const TimeStepType& dt )
@@ -397,7 +397,7 @@ VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 /*
  * Print status information
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::PrintSelf( std::ostream& os, Indent indent ) const

--- a/include/itkVariationalRegistrationFunction.h
+++ b/include/itkVariationalRegistrationFunction.h
@@ -46,7 +46,7 @@ namespace itk {
  *  \author Rene Werner
  *  \author Jan Ehrhardt
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField>
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 class VariationalRegistrationFunction :
   public FiniteDifferenceFunction< TDisplacementField >
 {

--- a/include/itkVariationalRegistrationFunction.hxx
+++ b/include/itkVariationalRegistrationFunction.hxx
@@ -26,7 +26,7 @@ namespace itk
 /**
  * Default constructor
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 VariationalRegistrationFunction< TFixedImage, TMovingImage, TDisplacementField >
 ::VariationalRegistrationFunction()
 {
@@ -52,7 +52,7 @@ VariationalRegistrationFunction< TFixedImage, TMovingImage, TDisplacementField >
 /**
  * Set the function state values before each iteration
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalRegistrationFunction< TFixedImage, TMovingImage, TDisplacementField >
 ::InitializeIteration()
@@ -73,7 +73,7 @@ VariationalRegistrationFunction< TFixedImage, TMovingImage, TDisplacementField >
 /**
  * Return the warped moving image.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 const typename VariationalRegistrationFunction< TFixedImage, TMovingImage, TDisplacementField >
 ::WarpedImagePointer
 VariationalRegistrationFunction< TFixedImage, TMovingImage, TDisplacementField >
@@ -85,7 +85,7 @@ VariationalRegistrationFunction< TFixedImage, TMovingImage, TDisplacementField >
 /**
  * Warp the moving image into the fixed image space.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalRegistrationFunction< TFixedImage, TMovingImage, TDisplacementField >
 ::WarpMovingImage()
@@ -112,7 +112,7 @@ VariationalRegistrationFunction< TFixedImage, TMovingImage, TDisplacementField >
  * Returns an empty struct that is used by the threads to include the
  * required update information for each thread.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void*
 VariationalRegistrationFunction< TFixedImage, TMovingImage, TDisplacementField >
 ::GetGlobalDataPointer() const
@@ -129,7 +129,7 @@ VariationalRegistrationFunction< TFixedImage, TMovingImage, TDisplacementField >
 /**
  * Update the metric and release the per-thread-global data.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalRegistrationFunction< TFixedImage, TMovingImage, TDisplacementField >
 ::ReleaseGlobalDataPointer( void *gd ) const
@@ -158,7 +158,7 @@ VariationalRegistrationFunction< TFixedImage, TMovingImage, TDisplacementField >
 /**
  * Standard "PrintSelf" method.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalRegistrationFunction< TFixedImage, TMovingImage, TDisplacementField >
 ::PrintSelf( std::ostream& os, Indent indent ) const

--- a/include/itkVariationalRegistrationGaussianRegularizer.h
+++ b/include/itkVariationalRegistrationGaussianRegularizer.h
@@ -42,7 +42,7 @@ namespace itk {
  *  \author Rene Werner
  *  \author Jan Ehrhardt
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 class VariationalRegistrationGaussianRegularizer
   : public VariationalRegistrationRegularizer< TDisplacementField >
 {

--- a/include/itkVariationalRegistrationGaussianRegularizer.hxx
+++ b/include/itkVariationalRegistrationGaussianRegularizer.hxx
@@ -31,7 +31,7 @@ namespace itk
 /**
  * Default constructor
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 VariationalRegistrationGaussianRegularizer< TDisplacementField >
 ::VariationalRegistrationGaussianRegularizer()
 {
@@ -47,7 +47,7 @@ VariationalRegistrationGaussianRegularizer< TDisplacementField >
 /**
  * Set the standard deviations.
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 void
 VariationalRegistrationGaussianRegularizer< TDisplacementField >
 ::SetStandardDeviations( double value )
@@ -62,7 +62,7 @@ VariationalRegistrationGaussianRegularizer< TDisplacementField >
  * Generate data by applying Gaussian regularization independently
  * on each component of the field
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 void
 VariationalRegistrationGaussianRegularizer< TDisplacementField >
 ::GenerateData()
@@ -135,7 +135,7 @@ VariationalRegistrationGaussianRegularizer< TDisplacementField >
 /*
  * Initialize flags
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 void
 VariationalRegistrationGaussianRegularizer< TDisplacementField >
 ::Initialize()
@@ -146,7 +146,7 @@ VariationalRegistrationGaussianRegularizer< TDisplacementField >
 /*
  * Print status information
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 void
 VariationalRegistrationGaussianRegularizer< TDisplacementField >
 ::PrintSelf( std::ostream& os, Indent indent ) const

--- a/include/itkVariationalRegistrationLogger.h
+++ b/include/itkVariationalRegistrationLogger.h
@@ -42,7 +42,7 @@ namespace itk {
  *  \author Rene Werner
  *  \author Jan Ehrhardt
  */
-template< class TRegistrationFilter, class TMRFilter >
+template< typename TRegistrationFilter, typename TMRFilter >
 class VariationalRegistrationLogger
   : public Command
 {

--- a/include/itkVariationalRegistrationLogger.hxx
+++ b/include/itkVariationalRegistrationLogger.hxx
@@ -30,7 +30,7 @@ namespace itk
 /**
  * Default constructor
  */
-template< class TRegistrationFilter, class TMRFilter >
+template< typename TRegistrationFilter, typename TMRFilter >
 VariationalRegistrationLogger< TRegistrationFilter, TMRFilter >
 ::VariationalRegistrationLogger()
 {
@@ -39,7 +39,7 @@ VariationalRegistrationLogger< TRegistrationFilter, TMRFilter >
 /**
  * Default destructor
  */
-template< class TRegistrationFilter, class TMRFilter >
+template< typename TRegistrationFilter, typename TMRFilter >
 VariationalRegistrationLogger< TRegistrationFilter, TMRFilter >
 ::~VariationalRegistrationLogger()
 {
@@ -48,7 +48,7 @@ VariationalRegistrationLogger< TRegistrationFilter, TMRFilter >
 /**
  *
  */
-template< class TRegistrationFilter, class TMRFilter >
+template< typename TRegistrationFilter, typename TMRFilter >
 void
 VariationalRegistrationLogger< TRegistrationFilter, TMRFilter >
 ::Execute( const itk::Object *caller, const itk::EventObject & event )
@@ -97,7 +97,7 @@ VariationalRegistrationLogger< TRegistrationFilter, TMRFilter >
 /**
  * Standard "PrintSelf" method.
  */
-template< class TRegistrationFilter, class TMRFilter >
+template< typename TRegistrationFilter, typename TMRFilter >
 void
 VariationalRegistrationLogger< TRegistrationFilter, TMRFilter >
 ::PrintSelf( std::ostream& os, Indent indent ) const

--- a/include/itkVariationalRegistrationMultiResolutionFilter.h
+++ b/include/itkVariationalRegistrationMultiResolutionFilter.h
@@ -77,7 +77,7 @@ namespace itk
  *  \author Rene Werner
  *  \author Jan Ehrhardt
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField, class  TRealType = float>
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename  TRealType = float>
 class VariationalRegistrationMultiResolutionFilter :
     public ImageToImageFilter< TDisplacementField, TDisplacementField >
 {

--- a/include/itkVariationalRegistrationMultiResolutionFilter.hxx
+++ b/include/itkVariationalRegistrationMultiResolutionFilter.hxx
@@ -33,7 +33,7 @@ namespace itk
 /**
  * Default constructor
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField, class TRealType >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType >
 VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDisplacementField, TRealType >
 ::VariationalRegistrationMultiResolutionFilter()
 {
@@ -74,7 +74,7 @@ VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDispla
 /*
  * Set the moving image image.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField, class TRealType >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType >
 void
 VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDisplacementField, TRealType >
 ::SetMovingImage( const MovingImageType * ptr )
@@ -85,7 +85,7 @@ VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDispla
 /*
  * Get the moving image image.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField, class TRealType >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType >
 const typename VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDisplacementField, TRealType >
 ::MovingImageType *
 VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDisplacementField, TRealType >
@@ -98,7 +98,7 @@ VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDispla
 /*
  * Set the fixed image.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField, class TRealType >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType >
 void
 VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDisplacementField, TRealType >
 ::SetFixedImage( const FixedImageType * ptr )
@@ -109,7 +109,7 @@ VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDispla
 /*
  * Get the fixed image.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField, class TRealType >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType >
 const typename VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDisplacementField, TRealType >
 ::FixedImageType *
 VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDisplacementField, TRealType >
@@ -122,7 +122,7 @@ VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDispla
 /*
  * Set the mask image.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField, class TRealType >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType >
 void
 VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDisplacementField, TRealType >
 ::SetMaskImage( const MaskImageType * ptr )
@@ -133,7 +133,7 @@ VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDispla
 /*
  * Get the mask image.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField, class TRealType >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType >
 const typename VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDisplacementField, TRealType >
 ::MaskImageType *
 VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDisplacementField, TRealType >
@@ -146,7 +146,7 @@ VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDispla
 /*
  * Get the number of required inputs, that are set correctly.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField, class TRealType >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType >
 std::vector< SmartPointer< DataObject > >::size_type
 VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDisplacementField, TRealType >
 ::GetNumberOfValidRequiredInputs() const
@@ -169,7 +169,7 @@ VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDispla
 /*
  * Set the number of multi-resolution levels.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField, class TRealType >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType >
 void
 VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDisplacementField, TRealType >
 ::SetNumberOfLevels( unsigned int num )
@@ -198,7 +198,7 @@ VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDispla
 /*
  * Standard PrintSelf method.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField, class TRealType >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType >
 void
 VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDisplacementField, TRealType >
 ::PrintSelf( std::ostream& os, Indent indent ) const
@@ -244,7 +244,7 @@ VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDispla
  * registrator and field_expander.
  *
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField, class TRealType >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType >
 void
 VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDisplacementField, TRealType >
 ::GenerateData()
@@ -531,7 +531,7 @@ VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDispla
 /*
  * Stop the registration, usually called by an observer.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField, class TRealType >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType >
 void
 VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDisplacementField, TRealType >
 ::StopRegistration()
@@ -543,7 +543,7 @@ VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDispla
 /*
  * Check if registration is stopped.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField, class TRealType >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType >
 bool
 VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDisplacementField, TRealType >
 ::Halt()
@@ -573,7 +573,7 @@ VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDispla
  * Override the default implementation for the case when no initial deformation
  * field is set. In this case, output information is copied from fixed image.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField, class TRealType >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType >
 void
 VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDisplacementField, TRealType >
 ::GenerateOutputInformation()
@@ -605,7 +605,7 @@ VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDispla
 /*
  *
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField, class TRealType >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType >
 void
 VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDisplacementField, TRealType >
 ::GenerateInputRequestedRegion()
@@ -645,7 +645,7 @@ VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDispla
 /*
  *
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField, class TRealType >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField, typename TRealType >
 void
 VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDisplacementField, TRealType >
 ::EnlargeOutputRequestedRegion(

--- a/include/itkVariationalRegistrationNCCFunction.h
+++ b/include/itkVariationalRegistrationNCCFunction.h
@@ -60,7 +60,7 @@ namespace itk {
  *  \author Rene Werner
  *  \author Jan Ehrhardt
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 class VariationalRegistrationNCCFunction :
   public VariationalRegistrationFunction< TFixedImage,  TMovingImage, TDisplacementField >
 {

--- a/include/itkVariationalRegistrationNCCFunction.hxx
+++ b/include/itkVariationalRegistrationNCCFunction.hxx
@@ -28,7 +28,7 @@ namespace itk
 /**
  * Default constructor
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 VariationalRegistrationNCCFunction< TFixedImage, TMovingImage, TDisplacementField >::VariationalRegistrationNCCFunction()
 {
   RadiusType r;
@@ -49,7 +49,7 @@ VariationalRegistrationNCCFunction< TFixedImage, TMovingImage, TDisplacementFiel
 /*
  * Standard "PrintSelf" method.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void VariationalRegistrationNCCFunction< TFixedImage, TMovingImage,
     TDisplacementField >::PrintSelf( std::ostream& os, Indent indent ) const
 {
@@ -69,7 +69,7 @@ void VariationalRegistrationNCCFunction< TFixedImage, TMovingImage,
 /*
  * Set the function state values before each iteration
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalRegistrationNCCFunction< TFixedImage, TMovingImage, TDisplacementField >
 ::InitializeIteration()
@@ -102,7 +102,7 @@ VariationalRegistrationNCCFunction< TFixedImage, TMovingImage, TDisplacementFiel
 /*
  * Compute update at a non boundary neighbourhood
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 typename VariationalRegistrationNCCFunction< TFixedImage, TMovingImage, TDisplacementField >::PixelType
 VariationalRegistrationNCCFunction< TFixedImage, TMovingImage, TDisplacementField >
 ::ComputeUpdate(

--- a/include/itkVariationalRegistrationRegularizer.h
+++ b/include/itkVariationalRegistrationRegularizer.h
@@ -43,7 +43,7 @@ namespace itk {
  *  \author Rene Werner
  *  \author Jan Ehrhardt
  */
-template< class TDisplacementField>
+template< typename TDisplacementField>
 class VariationalRegistrationRegularizer
   : public InPlaceImageFilter< TDisplacementField, TDisplacementField >
 {

--- a/include/itkVariationalRegistrationRegularizer.hxx
+++ b/include/itkVariationalRegistrationRegularizer.hxx
@@ -28,7 +28,7 @@ namespace itk
 /**
  * Default constructor
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 VariationalRegistrationRegularizer< TDisplacementField >
 ::VariationalRegistrationRegularizer()
 {
@@ -39,7 +39,7 @@ VariationalRegistrationRegularizer< TDisplacementField >
 /*
  * Print status information
  */
-template< class TDisplacementField >
+template< typename TDisplacementField >
 void
 VariationalRegistrationRegularizer< TDisplacementField >
 ::PrintSelf( std::ostream& os, Indent indent ) const

--- a/include/itkVariationalRegistrationSSDFunction.h
+++ b/include/itkVariationalRegistrationSSDFunction.h
@@ -48,7 +48,7 @@ namespace itk {
  *  \author Rene Werner
  *  \author Jan Ehrhardt
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 class VariationalRegistrationSSDFunction :
     public VariationalRegistrationFunction< TFixedImage, TMovingImage, TDisplacementField >
 {

--- a/include/itkVariationalRegistrationSSDFunction.hxx
+++ b/include/itkVariationalRegistrationSSDFunction.hxx
@@ -27,7 +27,7 @@ namespace itk
 /**
  * Default constructor
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 VariationalRegistrationSSDFunction< TFixedImage, TMovingImage, TDisplacementField >
 ::VariationalRegistrationSSDFunction()
 {
@@ -50,7 +50,7 @@ VariationalRegistrationSSDFunction< TFixedImage, TMovingImage, TDisplacementFiel
 /**
  * Set the function state values before each iteration
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalRegistrationSSDFunction< TFixedImage, TMovingImage, TDisplacementField >
 ::InitializeIteration()
@@ -78,7 +78,7 @@ VariationalRegistrationSSDFunction< TFixedImage, TMovingImage, TDisplacementFiel
 /**
  * Compute update at a specific neighborhood
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 typename VariationalRegistrationSSDFunction< TFixedImage, TMovingImage, TDisplacementField >
 ::PixelType
 VariationalRegistrationSSDFunction< TFixedImage, TMovingImage, TDisplacementField >
@@ -157,7 +157,7 @@ VariationalRegistrationSSDFunction< TFixedImage, TMovingImage, TDisplacementFiel
 /**
  * Standard "PrintSelf" method.
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalRegistrationSSDFunction< TFixedImage, TMovingImage, TDisplacementField >
 ::PrintSelf( std::ostream& os, Indent indent ) const

--- a/include/itkVariationalRegistrationStopCriterion.h
+++ b/include/itkVariationalRegistrationStopCriterion.h
@@ -64,7 +64,7 @@ namespace itk {
  *  \author Rene Werner
  *  \author Jan Ehrhardt
  */
-template< class TRegistrationFilter, class TMRFilter >
+template< typename TRegistrationFilter, typename TMRFilter >
 class VariationalRegistrationStopCriterion
   : public Command
 {

--- a/include/itkVariationalRegistrationStopCriterion.hxx
+++ b/include/itkVariationalRegistrationStopCriterion.hxx
@@ -28,7 +28,7 @@ namespace itk
 /**
  * Default constructor
  */
-template< class TRegistrationFilter, class TMRFilter >
+template< typename TRegistrationFilter, typename TMRFilter >
 VariationalRegistrationStopCriterion< TRegistrationFilter, TMRFilter >
 ::VariationalRegistrationStopCriterion()
 {
@@ -67,7 +67,7 @@ VariationalRegistrationStopCriterion< TRegistrationFilter, TMRFilter >
 /**
  * Default destructor
  */
-template< class TRegistrationFilter, class TMRFilter >
+template< typename TRegistrationFilter, typename TMRFilter >
 VariationalRegistrationStopCriterion< TRegistrationFilter, TMRFilter >
 ::~VariationalRegistrationStopCriterion()
 {
@@ -83,7 +83,7 @@ VariationalRegistrationStopCriterion< TRegistrationFilter, TMRFilter >
  * Not implemented because registration filter must not be const to
  * return the result of check
  */
-template< class TRegistrationFilter, class TMRFilter >
+template< typename TRegistrationFilter, typename TMRFilter >
 void
 VariationalRegistrationStopCriterion< TRegistrationFilter, TMRFilter >
 ::Execute( const itk::Object * itkNotUsed(caller), const itk::EventObject & itkNotUsed(event) )
@@ -94,7 +94,7 @@ VariationalRegistrationStopCriterion< TRegistrationFilter, TMRFilter >
 /**
  * Handle iteration event to check if stop criterion is fulfilled
  */
-template< class TRegistrationFilter, class TMRFilter >
+template< typename TRegistrationFilter, typename TMRFilter >
 void
 VariationalRegistrationStopCriterion< TRegistrationFilter, TMRFilter >
 ::Execute( itk::Object *caller, const itk::EventObject & event )
@@ -160,7 +160,7 @@ VariationalRegistrationStopCriterion< TRegistrationFilter, TMRFilter >
 /**
  *
  */
-template< class TRegistrationFilter, class TMRFilter >
+template< typename TRegistrationFilter, typename TMRFilter >
 void
 VariationalRegistrationStopCriterion< TRegistrationFilter, TMRFilter >
 ::SetModeForNextLevel(
@@ -224,7 +224,7 @@ VariationalRegistrationStopCriterion< TRegistrationFilter, TMRFilter >
 /**
  * Reset the fitting data
  */
-template< class TRegistrationFilter, class TMRFilter >
+template< typename TRegistrationFilter, typename TMRFilter >
 void
 VariationalRegistrationStopCriterion< TRegistrationFilter, TMRFilter >
 ::ResetFittingData()
@@ -257,7 +257,7 @@ VariationalRegistrationStopCriterion< TRegistrationFilter, TMRFilter >
 /**
  * Set the number of iterations used for line fitting
  */
-template< class TRegistrationFilter, class TMRFilter >
+template< typename TRegistrationFilter, typename TMRFilter >
 void
 VariationalRegistrationStopCriterion< TRegistrationFilter, TMRFilter >
 ::SetNumberOfFittingIterations( int it )
@@ -270,7 +270,7 @@ VariationalRegistrationStopCriterion< TRegistrationFilter, TMRFilter >
 /**
  * Set the metric value for the current iteration
  */
-template< class TRegistrationFilter, class TMRFilter >
+template< typename TRegistrationFilter, typename TMRFilter >
 void
 VariationalRegistrationStopCriterion< TRegistrationFilter, TMRFilter >
 ::SetNextMetricValue( const double value )
@@ -321,7 +321,7 @@ VariationalRegistrationStopCriterion< TRegistrationFilter, TMRFilter >
 /**
  * Perform stop criterion check. This function returns false, if error occurred.
  */
-template< class TRegistrationFilter, class TMRFilter >
+template< typename TRegistrationFilter, typename TMRFilter >
 bool
 VariationalRegistrationStopCriterion< TRegistrationFilter, TMRFilter >
 ::CheckStopRegistration()
@@ -460,7 +460,7 @@ VariationalRegistrationStopCriterion< TRegistrationFilter, TMRFilter >
 /**
  * Perform line fitting using linear regression
  */
-template< class TRegistrationFilter, class TMRFilter >
+template< typename TRegistrationFilter, typename TMRFilter >
 void
 VariationalRegistrationStopCriterion< TRegistrationFilter, TMRFilter >
 ::FitLine(
@@ -506,7 +506,7 @@ VariationalRegistrationStopCriterion< TRegistrationFilter, TMRFilter >
 /**
  * Standard "PrintSelf" method.
  */
-template< class TRegistrationFilter, class TMRFilter >
+template< typename TRegistrationFilter, typename TMRFilter >
 void
 VariationalRegistrationStopCriterion< TRegistrationFilter, TMRFilter >
 ::PrintSelf( std::ostream& os, Indent indent ) const

--- a/include/itkVariationalSymmetricDiffeomorphicRegistrationFilter.h
+++ b/include/itkVariationalSymmetricDiffeomorphicRegistrationFilter.h
@@ -86,7 +86,7 @@ namespace itk {
  *      <i>Statistical modeling of 4D respiratory lung motion using diffeomorphic
  *      image registration.</i> IEEE Trans. Med. Imaging, 30(2), 2011
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField>
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField>
 class VariationalSymmetricDiffeomorphicRegistrationFilter
   : public VariationalDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 {

--- a/include/itkVariationalSymmetricDiffeomorphicRegistrationFilter.hxx
+++ b/include/itkVariationalSymmetricDiffeomorphicRegistrationFilter.hxx
@@ -28,7 +28,7 @@ namespace itk
 /**
  * Default constructor
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 VariationalSymmetricDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::VariationalSymmetricDiffeomorphicRegistrationFilter()
 {
@@ -39,7 +39,7 @@ VariationalSymmetricDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, 
 /*
  * Initialize flags
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalSymmetricDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::Initialize()
@@ -102,7 +102,7 @@ VariationalSymmetricDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, 
 /*
  * Set the function state values before each iteration
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalSymmetricDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::InitializeBackwardIteration()
@@ -126,7 +126,7 @@ VariationalSymmetricDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, 
   rfp->InitializeIteration();
 }
 
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 typename VariationalSymmetricDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::TimeStepType
 VariationalSymmetricDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
@@ -163,7 +163,7 @@ VariationalSymmetricDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, 
   return 0.5 * dt;
 }
 
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalSymmetricDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::ApplyUpdate( const TimeStepType& dt )
@@ -175,7 +175,7 @@ VariationalSymmetricDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, 
   this->CalcInverseDeformationFromVelocityField( this->GetVelocityField() );
 }
 
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalSymmetricDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::ThreadedApplyUpdate( const TimeStepType& dt, const ThreadRegionType &regionToProcess, unsigned int )
@@ -205,7 +205,7 @@ VariationalSymmetricDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, 
  * Calculates the inverse deformation field by calculating the exponential
  * of the negative velocity field
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalSymmetricDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::CalcInverseDeformationFromVelocityField( const DisplacementFieldType * velocityField )
@@ -225,7 +225,7 @@ VariationalSymmetricDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, 
 /*
  * Print status information
  */
-template< class TFixedImage, class TMovingImage, class TDisplacementField >
+template< typename TFixedImage, typename TMovingImage, typename TDisplacementField >
 void
 VariationalSymmetricDiffeomorphicRegistrationFilter< TFixedImage, TMovingImage, TDisplacementField >
 ::PrintSelf( std::ostream& os, Indent indent ) const


### PR DESCRIPTION
As discussed in:
http://review.source.kitware.com/#/c/12655/

the use of the template keyword "class" was substituted by "typename" in
the toolkit for the reasons stated in that topic.