### PR TITLE
BUG: Fix RTTI in class names.

### DIFF
--- a/include/itkVariationalDiffeomorphicRegistrationFilter.h
+++ b/include/itkVariationalDiffeomorphicRegistrationFilter.h
@@ -94,7 +94,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(itkVariationalDiffeomorphicRegistrationFilter, VariationalRegistrationFilter );
+  itkTypeMacro( VariationalDiffeomorphicRegistrationFilter, VariationalRegistrationFilter );
 
   /** Get image dimension. */
   static constexpr unsigned int ImageDimension = Superclass::ImageDimension;

--- a/include/itkVariationalRegistrationDiffusionRegularizer.h
+++ b/include/itkVariationalRegistrationDiffusionRegularizer.h
@@ -65,7 +65,8 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(itkVariationalRegistrationDiffusionRegularizer, itkVariationalRegistrationRegularizer);
+  itkTypeMacro( VariationalRegistrationDiffusionRegularizer, 
+    VariationalRegistrationRegularizer);
 
   /** Dimensionality of input and output data is assumed to be the same. */
   static constexpr unsigned int ImageDimension = TDisplacementField::ImageDimension;

--- a/include/itkVariationalRegistrationFilter.h
+++ b/include/itkVariationalRegistrationFilter.h
@@ -116,7 +116,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(itkVariationalRegistrationFilter, DenseFiniteDifferenceImageFilter );
+  itkTypeMacro( VariationalRegistrationFilter, DenseFiniteDifferenceImageFilter );
 
   /** Get image dimension. */
   static constexpr unsigned int ImageDimension = Superclass::ImageDimension;

--- a/include/itkVariationalRegistrationGaussianRegularizer.h
+++ b/include/itkVariationalRegistrationGaussianRegularizer.h
@@ -60,7 +60,8 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(itkVariationalRegistrationGaussianRegularizer, itkVariationalRegistrationRegularizer);
+  itkTypeMacro( VariationalRegistrationGaussianRegularizer, 
+    VariationalRegistrationRegularizer);
 
   /** Dimensionality of input and output data is assumed to be the same. */
   static constexpr unsigned int ImageDimension = TDisplacementField::ImageDimension;

--- a/include/itkVariationalRegistrationRegularizer.h
+++ b/include/itkVariationalRegistrationRegularizer.h
@@ -61,7 +61,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(itkVariationalRegistrationRegularizer, InPlaceImageFilter);
+  itkTypeMacro( VariationalRegistrationRegularizer, InPlaceImageFilter);
 
   static constexpr unsigned int ImageDimension = TDisplacementField::ImageDimension;
 

--- a/include/itkVariationalSymmetricDiffeomorphicRegistrationFilter.h
+++ b/include/itkVariationalSymmetricDiffeomorphicRegistrationFilter.h
@@ -104,7 +104,8 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(itkVariationalSymmetricDiffeomorphicRegistrationFilter, VariationalDiffeomorphicRegistrationFilter);
+  itkTypeMacro( VariationalSymmetricDiffeomorphicRegistrationFilter,
+    VariationalDiffeomorphicRegistrationFilter);
 
   /** Get image dimension. */
   static constexpr unsigned int ImageDimension = Superclass::ImageDimension;


### PR DESCRIPTION
Fix the RTTI methods: remove the `itk` prefix in class names.