### PR TITLE
BUG: Remove override keyword.

### DIFF
--- a/include/itkVariationalRegistrationFilter.h
+++ b/include/itkVariationalRegistrationFilter.h
@@ -267,7 +267,7 @@ protected:
 
   /** Initialize the state of filter and equation before each iteration.
    * Progress feedback is implemented as part of this method. */
-  void InitializeIteration() override;
+  void InitializeIteration();
 
   /** Apply update. */
   void ApplyUpdate( const TimeStepType& dt ) override;


### PR DESCRIPTION
Remove the `override` keyword from the
`itk::VariationalRegistrationFilter::InitializeIteration` method: the base
class `itk::DenseFiniteDifferenceImageFilter` does not have such a method,
and thus it cannot be overriden.

Fixes Doxygen warnings raised at:
https://open.cdash.org/viewBuildError.php?type=1&buildid=5578653