### PR TITLE
COMP: Prefer C++11 math over vcl_*

### DIFF
--- a/include/itkVariationalRegistrationCurvatureRegularizer.hxx
+++ b/include/itkVariationalRegistrationCurvatureRegularizer.hxx
@@ -251,7 +251,7 @@ bool VariationalRegistrationCurvatureRegularizer<TDisplacementField>::Initialize
       const double a = (vnl_math::pi * (idx + 1)) / static_cast<double>( m_Size[dim] );
 //      const double a = (vnl_math::pi * idx ) / static_cast<double>(m_Size[dim]);
 
-      m_DiagonalMatrix[dim][idx] = -2.0 + 2.0 * vcl_cos( a );
+      m_DiagonalMatrix[dim][idx] = -2.0 + 2.0 * std::cos( a );
 
     }
   }

--- a/include/itkVariationalRegistrationElasticRegularizer.hxx
+++ b/include/itkVariationalRegistrationElasticRegularizer.hxx
@@ -244,8 +244,8 @@ VariationalRegistrationElasticRegularizer< TDisplacementField >
       {
       a = (2.0 * vnl_math::pi * n) / static_cast< double >( this->m_Size[i] );
 
-      this->m_MatrixCos[i][n] = 2.0 * vcl_cos( a );
-      this->m_MatrixSin[i][n] = vcl_sin( a );
+      this->m_MatrixCos[i][n] = 2.0 * std::cos( a );
+      this->m_MatrixSin[i][n] = std::sin( a );
       }
     }
 

--- a/include/itkVariationalRegistrationFunction.hxx
+++ b/include/itkVariationalRegistrationFunction.hxx
@@ -146,7 +146,7 @@ VariationalRegistrationFunction< TFixedImage, TMovingImage, TDisplacementField >
     {
     m_Metric = m_SumOfMetricValues /
         static_cast< double >( m_NumberOfPixelsProcessed );
-    m_RMSChange = vcl_sqrt( m_SumOfSquaredChange /
+    m_RMSChange = std::sqrt( m_SumOfSquaredChange /
         static_cast< double >( m_NumberOfPixelsProcessed ) );
     }
 

--- a/include/itkVariationalRegistrationStopCriterion.hxx
+++ b/include/itkVariationalRegistrationStopCriterion.hxx
@@ -279,13 +279,13 @@ VariationalRegistrationStopCriterion< TRegistrationFilter, TMRFilter >
 
   if( m_LineFittingUseAbsoluteValues )
     {
-    absValue = vcl_fabs( value );
+    absValue = std::fabs( value );
     }
   else
     if( value < 0 )
       {
       itkWarningMacro( << "Metric value is < 0" );
-      absValue = vcl_fabs( value );
+      absValue = std::fabs( value );
       }
 
   if( m_ElapsedIterations == 0 || m_MaxMetricValue < 0 )
@@ -426,7 +426,7 @@ VariationalRegistrationStopCriterion< TRegistrationFilter, TMRFilter >
       }
 
     // Check if regression line slope is above threshold.
-    if( vcl_fabs( m ) < m_RegressionLineSlopeThreshold )
+    if( std::fabs( m ) < m_RegressionLineSlopeThreshold )
       {
       // If max distance check should be performed, check if the maximal
       // distance of a value to the regression line is above a threshold.
@@ -437,7 +437,7 @@ VariationalRegistrationStopCriterion< TRegistrationFilter, TMRFilter >
         double dist = 0.0;
         for( int k = 0; k < m_NumberOfFittingIterations; k++ )
           {
-          dist = vcl_fabs( m_DistanceArrayForFitting[k] -
+          dist = std::fabs( m_DistanceArrayForFitting[k] -
               (m * m_IterationArray[k] + b) );
 
           // If distance check is above threshold, return false

--- a/src/VariationalRegistrationMain.cxx
+++ b/src/VariationalRegistrationMain.cxx
@@ -715,7 +715,7 @@ int main( int argc, char *argv[] )
   case 0:
     {
     GaussianRegularizerType::Pointer gaussRegularizer = GaussianRegularizerType::New();
-    gaussRegularizer->SetStandardDeviations( vcl_sqrt( regulVar ) );
+    gaussRegularizer->SetStandardDeviations( std::sqrt( regulVar ) );
     regularizer = gaussRegularizer;
     }
     break;


### PR DESCRIPTION
The vcl_ functions are aliases to the C++11 variants,
so just use C++11 directly.