### PR TITLE
COMP: Future proof vnl_math_XXX function usage.

### DIFF
--- a/include/itkVariationalRegistrationCurvatureRegularizer.hxx
+++ b/include/itkVariationalRegistrationCurvatureRegularizer.hxx
@@ -406,12 +406,12 @@ void VariationalRegistrationCurvatureRegularizer<TDisplacementField>::ThreadedSo
   ValueType meanSquaredSpacing = 0.0;
   for( unsigned int i = 0; i < ImageDimension; ++i )
   {
-    meanSquaredSpacing += vnl_math_sqr( m_Spacing[i] );
+    meanSquaredSpacing += itk::Math::sqr( m_Spacing[i] );
   }
   meanSquaredSpacing /= ImageDimension;
 
   // compute weight including the spacing of this dimension
-  const double weight = m_Alpha * meanSquaredSpacing / vnl_math_sqr( m_Spacing[currentDimension] );
+  const double weight = m_Alpha * meanSquaredSpacing / itk::Math::sqr( m_Spacing[currentDimension] );
 
   // Iterate over each pixel in thread range
   double diagValue = 0;

--- a/include/itkVariationalRegistrationDemonsFunction.hxx
+++ b/include/itkVariationalRegistrationDemonsFunction.hxx
@@ -19,7 +19,7 @@
 #define itkVariationalRegistrationDemonsFunction_hxx
 
 #include "itkVariationalRegistrationDemonsFunction.h"
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 
 namespace itk
 {
@@ -158,11 +158,11 @@ VariationalRegistrationDemonsFunction< TFixedImage, TMovingImage, TDisplacementF
 
   // Calculate spped value
   const double speedValue = fixedValue - warpedValue;
-  const double sqr_speedValue = vnl_math_sqr( speedValue );
+  const double sqr_speedValue = itk::Math::sqr( speedValue );
 
   // Calculate update
   PixelType update;
-  if( vnl_math_abs( speedValue ) < m_IntensityDifferenceThreshold )
+  if( itk::Math::abs( speedValue ) < m_IntensityDifferenceThreshold )
     {
     update = m_ZeroUpdateReturn;
     }

--- a/include/itkVariationalRegistrationElasticRegularizer.hxx
+++ b/include/itkVariationalRegistrationElasticRegularizer.hxx
@@ -395,13 +395,13 @@ VariationalRegistrationElasticRegularizer< TDisplacementField >
     double d11, d12, d13, d22, d23, d33;
     double invD11, invD12, invD13, invD22, invD23, invD33;
 
-    const double mu_hx2 = m_Mu / vnl_math_sqr( m_Spacing[0] );
-    const double mu_hy2 = m_Mu / vnl_math_sqr( m_Spacing[1] );
-    const double mu_hz2 = m_Mu / vnl_math_sqr( m_Spacing[2] );
+    const double mu_hx2 = m_Mu / itk::Math::sqr( m_Spacing[0] );
+    const double mu_hy2 = m_Mu / itk::Math::sqr( m_Spacing[1] );
+    const double mu_hz2 = m_Mu / itk::Math::sqr( m_Spacing[2] );
 
-    const double lambdaPlus2mu_hx2 = (m_Lambda + 2 * m_Mu) / vnl_math_sqr( m_Spacing[0] );
-    const double lambdaPlus2mu_hy2 = (m_Lambda + 2 * m_Mu) / vnl_math_sqr( m_Spacing[1] );
-    const double lambdaPlus2mu_hz2 = (m_Lambda + 2 * m_Mu) / vnl_math_sqr( m_Spacing[2] );
+    const double lambdaPlus2mu_hx2 = (m_Lambda + 2 * m_Mu) / itk::Math::sqr( m_Spacing[0] );
+    const double lambdaPlus2mu_hy2 = (m_Lambda + 2 * m_Mu) / itk::Math::sqr( m_Spacing[1] );
+    const double lambdaPlus2mu_hz2 = (m_Lambda + 2 * m_Mu) / itk::Math::sqr( m_Spacing[2] );
 
     const double lambdaPlusmu_hxhy = (m_Lambda + m_Mu) / (m_Spacing[0] * m_Spacing[1]);
     const double lambdaPlusmu_hxhz = (m_Lambda + m_Mu) / (m_Spacing[0] * m_Spacing[2]);
@@ -410,7 +410,7 @@ VariationalRegistrationElasticRegularizer< TDisplacementField >
     ValueType meanSquaredSpacing = 0.0;
     for( unsigned int i = 0; i < ImageDimension; ++i )
       {
-      meanSquaredSpacing += vnl_math_sqr( m_Spacing[i] );
+      meanSquaredSpacing += itk::Math::sqr( m_Spacing[i] );
       }
     meanSquaredSpacing /= 3.0;
 
@@ -535,18 +535,18 @@ VariationalRegistrationElasticRegularizer< TDisplacementField >
     double d11, d12, d22;
     double invD11, invD12, invD22;
 
-    const double mu_hx2 = m_Mu / vnl_math_sqr( m_Spacing[0] );
-    const double mu_hy2 = m_Mu / vnl_math_sqr( m_Spacing[1] );
+    const double mu_hx2 = m_Mu / itk::Math::sqr( m_Spacing[0] );
+    const double mu_hy2 = m_Mu / itk::Math::sqr( m_Spacing[1] );
 
-    const double lambdaPlus2mu_hx2 = (m_Lambda + 2 * m_Mu) / vnl_math_sqr( m_Spacing[0] );
-    const double lambdaPlus2mu_hy2 = (m_Lambda + 2 * m_Mu) / vnl_math_sqr( m_Spacing[1] );
+    const double lambdaPlus2mu_hx2 = (m_Lambda + 2 * m_Mu) / itk::Math::sqr( m_Spacing[0] );
+    const double lambdaPlus2mu_hy2 = (m_Lambda + 2 * m_Mu) / itk::Math::sqr( m_Spacing[1] );
 
     const double lambdaPlusmu_hxhy = (m_Lambda + m_Mu) / (m_Spacing[0] * m_Spacing[1]);
 
     ValueType meanSquaredSpacing = 0.0;
     for( unsigned int i = 0; i < ImageDimension; ++i )
       {
-      meanSquaredSpacing += vnl_math_sqr( m_Spacing[i] );
+      meanSquaredSpacing += itk::Math::sqr( m_Spacing[i] );
       }
     meanSquaredSpacing /= ImageDimension;
 

--- a/include/itkVariationalRegistrationFastNCCFunction.hxx
+++ b/include/itkVariationalRegistrationFastNCCFunction.hxx
@@ -20,7 +20,7 @@
 
 #include "itkVariationalRegistrationFastNCCFunction.h"
 #include "itkExceptionObject.h"
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 
 namespace itk
 {

--- a/include/itkVariationalRegistrationGaussianRegularizer.hxx
+++ b/include/itkVariationalRegistrationGaussianRegularizer.hxx
@@ -90,7 +90,7 @@ VariationalRegistrationGaussianRegularizer< TDisplacementField >
     // smooth along this dimension
     opers[j].SetDirection( j );
     typename StandardDeviationsType::ValueType variance =
-        vnl_math_sqr( this->GetStandardDeviations()[j] );
+        itk::Math::sqr( this->GetStandardDeviations()[j] );
     if( this->GetUseImageSpacing() )
       {
       // TODO Considering image spacing in a multi resolution setting leads to
@@ -106,7 +106,7 @@ VariationalRegistrationGaussianRegularizer< TDisplacementField >
       //   }
       // // convert the variance from physical units to pixels
       // const double s = this->GetInput()->GetSpacing()[j];
-      // opers[j].SetVariance( variance / vnl_math_sqr(s) );
+      // opers[j].SetVariance( variance / itk::Math::sqr(s) );
       }
     else
       {

--- a/include/itkVariationalRegistrationLogger.hxx
+++ b/include/itkVariationalRegistrationLogger.hxx
@@ -18,7 +18,7 @@
 #ifndef itkVariationalRegistrationLogger_hxx
 #define itkVariationalRegistrationLogger_hxx
 
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 #include "itkVariationalRegistrationLogger.h"
 
 #include "itkVariationalRegistrationFilter.h"

--- a/include/itkVariationalRegistrationMultiResolutionFilter.hxx
+++ b/include/itkVariationalRegistrationMultiResolutionFilter.hxx
@@ -25,7 +25,7 @@
 #include "itkBinaryDilateImageFilter.h"
 #include "itkBinaryThresholdImageFilter.h"
 #include "itkImageRegionIterator.h"
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 
 namespace itk
 {
@@ -302,13 +302,13 @@ VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDispla
   m_ElapsedLevels = 0;
   m_StopRegistrationFlag = false;
 
-  unsigned int movingLevel = vnl_math_min(
+  unsigned int movingLevel = std::min(
       (int) m_ElapsedLevels, (int) m_MovingImagePyramid->GetNumberOfLevels() );
 
-  unsigned int fixedLevel = vnl_math_min(
+  unsigned int fixedLevel = std::min(
       (int) m_ElapsedLevels, (int) m_FixedImagePyramid->GetNumberOfLevels() );
 
-  unsigned int maskLevel = vnl_math_min(
+  unsigned int maskLevel = std::min(
       (int) m_ElapsedLevels, (int) m_MaskImagePyramid->GetNumberOfLevels() );
 
   // Get valid input deformation field.
@@ -464,11 +464,11 @@ VariationalRegistrationMultiResolutionFilter< TFixedImage, TMovingImage, TDispla
     this->InvokeEvent( IterationEvent() );
 
     // Increment level counter.
-    movingLevel = vnl_math_min( (int) m_ElapsedLevels,
+    movingLevel = std::min( (int) m_ElapsedLevels,
         (int) m_MovingImagePyramid->GetNumberOfLevels() );
-    fixedLevel = vnl_math_min( (int) m_ElapsedLevels,
+    fixedLevel = std::min( (int) m_ElapsedLevels,
         (int) m_FixedImagePyramid->GetNumberOfLevels() );
-    maskLevel = vnl_math_min( (int) m_ElapsedLevels,
+    maskLevel = std::min( (int) m_ElapsedLevels,
         (int) m_MaskImagePyramid->GetNumberOfLevels() );
 
     // We can release data from pyramid which are no longer required.

--- a/include/itkVariationalRegistrationNCCFunction.hxx
+++ b/include/itkVariationalRegistrationNCCFunction.hxx
@@ -20,7 +20,7 @@
 
 #include "itkVariationalRegistrationNCCFunction.h"
 #include "itkExceptionObject.h"
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 
 namespace itk
 {

--- a/include/itkVariationalRegistrationSSDFunction.hxx
+++ b/include/itkVariationalRegistrationSSDFunction.hxx
@@ -19,7 +19,7 @@
 #define itkVariationalRegistrationSSDFunction_hxx
 
 #include "itkVariationalRegistrationSSDFunction.h"
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 
 namespace itk
 {
@@ -102,11 +102,11 @@ VariationalRegistrationSSDFunction< TFixedImage, TMovingImage, TDisplacementFiel
 
   // Calculate spped value
   const double speedValue = fixedValue - warpedValue;
-  const double sqr_speedValue = vnl_math_sqr( speedValue );
+  const double sqr_speedValue = itk::Math::sqr( speedValue );
 
   // Calculate update
   PixelType update;
-  if( vnl_math_abs( speedValue ) < m_IntensityDifferenceThreshold )
+  if( itk::Math::abs( speedValue ) < m_IntensityDifferenceThreshold )
     {
     update = m_ZeroUpdateReturn;
     }

--- a/include/itkVariationalRegistrationStopCriterion.hxx
+++ b/include/itkVariationalRegistrationStopCriterion.hxx
@@ -20,7 +20,7 @@
 
 #include "itkVariationalRegistrationStopCriterion.h"
 
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 
 namespace itk
 {
@@ -486,10 +486,10 @@ VariationalRegistrationStopCriterion< TRegistrationFilter, TMRFilter >
       {
       sumx += x[i];
       sumy += y[i];
-      sumx2 += vnl_math_sqr( x[i] );
+      sumx2 += itk::Math::sqr( x[i] );
       sumxy += x[i] * y[i];
       }
-    divisor = (sumx2 - (vnl_math_sqr( sumx ) / dn));
+    divisor = (sumx2 - (itk::Math::sqr( sumx ) / dn));
     if( divisor != 0 )
       {
       *m = (sumxy - ((sumx * sumy) / dn)) / divisor;

--- a/src/VariationalRegistrationMain.cxx
+++ b/src/VariationalRegistrationMain.cxx
@@ -85,7 +85,7 @@ extern "C"
 #include "itkImageFileWriter.h"
 #include "itkHistogramMatchingImageFilter.h"
 
-#include <vnl/vnl_math.h>
+#include <itkMath.h>
 
 using namespace itk;
 

--- a/test/VariationalRegistrationFilterTest.cxx
+++ b/test/VariationalRegistrationFilterTest.cxx
@@ -69,7 +69,7 @@ typename TImage::PixelType backgnd )
   it.GoToBegin();
 
   typename TImage::IndexType index;
-  double r2 = vnl_math_sqr( radius );
+  double r2 = itk::Math::sqr( radius );
 
   while( !it.IsAtEnd() )
     {
@@ -77,7 +77,7 @@ typename TImage::PixelType backgnd )
     double distance = 0;
     for( unsigned int j = 0; j < TImage::ImageDimension; j++ )
       {
-      distance += vnl_math_sqr((double) index[j] - center[j]);
+      distance += itk::Math::sqr((double) index[j] - center[j]);
       }
     if( distance <= r2 ) it.Set( foregnd );
     else it.Set( backgnd );

--- a/test/VariationalRegistrationMultiResolutionFilterTest.cxx
+++ b/test/VariationalRegistrationMultiResolutionFilterTest.cxx
@@ -69,7 +69,7 @@ typename TImage::PixelType backgnd )
   it.GoToBegin();
 
   typename TImage::IndexType index;
-  double r2 = vnl_math_sqr( radius );
+  double r2 = itk::Math::sqr( radius );
 
   while( !it.IsAtEnd() )
     {
@@ -77,7 +77,7 @@ typename TImage::PixelType backgnd )
     double distance = 0;
     for( unsigned int j = 0; j < TImage::ImageDimension; j++ )
       {
-      distance += vnl_math_sqr((double) index[j] - center[j]);
+      distance += itk::Math::sqr((double) index[j] - center[j]);
       }
     if( distance <= r2 ) it.Set( foregnd );
     else it.Set( backgnd );


### PR DESCRIPTION
Prefer C++ over aliased names vnl_math_[min|max] -> std::[min|max]
Prefer vnl_math::abs over deprecated alias vnl_math_abs

In all compilers currently supported by VXL, vnl_math_[min|max]
could be replaced with std::[min|max] without loss of
functionality.  This also circumvents part of the backwards
compatibility requirements as vnl_math_ has been recently
replaced with a namespace of vnl_math::.

Since Wed Nov 14 07:42:48 2012:
The vnl_math_* functions use #define aliases to their
vnl_math::* counterparts in the "real" vnl_math:: namespace.

The new syntax should be backwards compatible to
VXL versions as old as 2012.