### PR TITLE
BUG: Fix wrong output argument in test.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,7 +33,7 @@ add_custom_target(BuildExecutablesUsedInTests COMMAND echo "Dummy target"
 
 function(Test2D TestName OutputExt)
   if (OutputExt)
-    set(OutParam "-O ${TEMP}/${TestName}.${OutputExt}")
+    set(OutParam "${TEMP}/${TestName}.${OutputExt}")
   endif()
 
   itk_add_test(NAME ${TestName}
@@ -41,7 +41,7 @@ function(Test2D TestName OutputExt)
     --compare DATA{Baseline/${TestName}.tif} ${TEMP}/${TestName}.tif
     $<TARGET_FILE:VariationalRegistration2D>
     -F DATA{Input/img1.png} -M DATA{Input/img2.png} -l 4 -p 1 -g 0.00001
-    ${ARGN} -W ${TEMP}/${TestName}.tif ${OutParam} )
+    ${ARGN} -W ${TEMP}/${TestName}.tif -O ${OutParam} )
   
   SET_TESTS_PROPERTIES(${TestName} PROPERTIES
     DEPENDS BuildExecutablesUsedInTests)


### PR DESCRIPTION
Fix wrong output argument being fed into the `itk_add_test` command: a
white space before the output filename was being added as a consequence of
setting the `CMake` `OutParam` variable as a string including the `-O`
option along with its corresponding value.

Thus, the filename was preceded by a white space and when trying to write
the test output the test was failing.

This should help fixing the CI failures.