### PR TITLE
COMP: Future proof vnl_math_XXX function usage.

### DIFF
--- a/include/itkVariationalRegistrationCurvatureRegularizer.hxx
+++ b/include/itkVariationalRegistrationCurvatureRegularizer.hxx
@@ -248,8 +248,8 @@ bool VariationalRegistrationCurvatureRegularizer<TDisplacementField>::Initialize
       // This is implemented according to class CurvatureRegistrationFilter by
       // T. Rohlfing.
 
-      const double a = (vnl_math::pi * (idx + 1)) / static_cast<double>( m_Size[dim] );
-//      const double a = (vnl_math::pi * idx ) / static_cast<double>(m_Size[dim]);
+      const double a = (itk::Math::pi * (idx + 1)) / static_cast<double>( m_Size[dim] );
+//      const double a = (itk::Math::pi * idx ) / static_cast<double>(m_Size[dim]);
 
       m_DiagonalMatrix[dim][idx] = -2.0 + 2.0 * std::cos( a );
 

--- a/include/itkVariationalRegistrationElasticRegularizer.hxx
+++ b/include/itkVariationalRegistrationElasticRegularizer.hxx
@@ -242,7 +242,7 @@ VariationalRegistrationElasticRegularizer< TDisplacementField >
 
     for( unsigned int n = 0; n < this->m_ComplexSize[i]; n++ )
       {
-      a = (2.0 * vnl_math::pi * n) / static_cast< double >( this->m_Size[i] );
+      a = (2.0 * itk::Math::pi * n) / static_cast< double >( this->m_Size[i] );
 
       this->m_MatrixCos[i][n] = 2.0 * std::cos( a );
       this->m_MatrixSin[i][n] = std::sin( a );


### PR DESCRIPTION
Prefer C++ over aliased names vnl_math_[min|max] -> std::[min|max]
Prefer vnl_math::abs over deprecated alias vnl_math_abs

In all compilers currently supported by VXL, vnl_math_[min|max]
could be replaced with std::[min|max] without loss of
functionality.  This also circumvents part of the backwards
compatibility requirements as vnl_math_ has been recently
replaced with a namespace of vnl_math::.

Since Wed Nov 14 07:42:48 2012:
The vnl_math_* functions use #define aliases to their
vnl_math::* counterparts in the "real" vnl_math:: namespace.

The new syntax should be backwards compatible to
VXL versions as old as 2012.

Prefer to use itk::Math:: over vnl_math:: namespace