### PR TITLE
STYLE: Rename ITK_DISALLOW_COPY_AND_ASSIGN to ITK_DISALLOW_COPY_A…

### DIFF
--- a/include/itkContinuousBorderWarpImageFilter.h
+++ b/include/itkContinuousBorderWarpImageFilter.h
@@ -59,7 +59,7 @@ template <typename TInputImage, typename TOutputImage, typename TDisplacementFie
 class ContinuousBorderWarpImageFilter : public WarpImageFilter<TInputImage, TOutputImage, TDisplacementField>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ContinuousBorderWarpImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(ContinuousBorderWarpImageFilter);
 
   /** Standard class type alias. */
   using Self = ContinuousBorderWarpImageFilter;

--- a/include/itkVariationalDiffeomorphicRegistrationFilter.h
+++ b/include/itkVariationalDiffeomorphicRegistrationFilter.h
@@ -83,7 +83,7 @@ class VariationalDiffeomorphicRegistrationFilter
   : public VariationalRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalDiffeomorphicRegistrationFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(VariationalDiffeomorphicRegistrationFilter);
 
   /** Standard class type alias */
   using Self = VariationalDiffeomorphicRegistrationFilter;

--- a/include/itkVariationalRegistrationCurvatureRegularizer.h
+++ b/include/itkVariationalRegistrationCurvatureRegularizer.h
@@ -63,7 +63,7 @@ template <typename TDisplacementField>
 class VariationalRegistrationCurvatureRegularizer : public VariationalRegistrationRegularizer<TDisplacementField>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalRegistrationCurvatureRegularizer);
+  ITK_DISALLOW_COPY_AND_MOVE(VariationalRegistrationCurvatureRegularizer);
 
   /** Standard class type alias */
   using Self = VariationalRegistrationCurvatureRegularizer;

--- a/include/itkVariationalRegistrationDemonsFunction.h
+++ b/include/itkVariationalRegistrationDemonsFunction.h
@@ -57,7 +57,7 @@ class VariationalRegistrationDemonsFunction
   : public VariationalRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalRegistrationDemonsFunction);
+  ITK_DISALLOW_COPY_AND_MOVE(VariationalRegistrationDemonsFunction);
 
   /** Standard class type alias. */
   using Self = VariationalRegistrationDemonsFunction;

--- a/include/itkVariationalRegistrationDiffusionRegularizer.h
+++ b/include/itkVariationalRegistrationDiffusionRegularizer.h
@@ -51,7 +51,7 @@ template <typename TDisplacementField>
 class VariationalRegistrationDiffusionRegularizer : public VariationalRegistrationRegularizer<TDisplacementField>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalRegistrationDiffusionRegularizer);
+  ITK_DISALLOW_COPY_AND_MOVE(VariationalRegistrationDiffusionRegularizer);
 
   /** Standard class type alias */
   using Self = VariationalRegistrationDiffusionRegularizer;

--- a/include/itkVariationalRegistrationElasticRegularizer.h
+++ b/include/itkVariationalRegistrationElasticRegularizer.h
@@ -59,7 +59,7 @@ template <typename TDisplacementField>
 class VariationalRegistrationElasticRegularizer : public VariationalRegistrationRegularizer<TDisplacementField>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalRegistrationElasticRegularizer);
+  ITK_DISALLOW_COPY_AND_MOVE(VariationalRegistrationElasticRegularizer);
 
   /** Standard class type alias */
   using Self = VariationalRegistrationElasticRegularizer;

--- a/include/itkVariationalRegistrationFastNCCFunction.h
+++ b/include/itkVariationalRegistrationFastNCCFunction.h
@@ -66,7 +66,7 @@ class VariationalRegistrationFastNCCFunction
   : public VariationalRegistrationNCCFunction<TFixedImage, TMovingImage, TDisplacementField>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalRegistrationFastNCCFunction);
+  ITK_DISALLOW_COPY_AND_MOVE(VariationalRegistrationFastNCCFunction);
 
   /** Standard class type alias. */
   using Self = VariationalRegistrationFastNCCFunction;

--- a/include/itkVariationalRegistrationFilter.h
+++ b/include/itkVariationalRegistrationFilter.h
@@ -99,7 +99,7 @@ template <typename TFixedImage, typename TMovingImage, typename TDisplacementFie
 class VariationalRegistrationFilter : public DenseFiniteDifferenceImageFilter<TDisplacementField, TDisplacementField>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalRegistrationFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(VariationalRegistrationFilter);
 
   /** Standard class type alias */
   using Self = VariationalRegistrationFilter;

--- a/include/itkVariationalRegistrationFunction.h
+++ b/include/itkVariationalRegistrationFunction.h
@@ -52,7 +52,7 @@ template <typename TFixedImage, typename TMovingImage, typename TDisplacementFie
 class VariationalRegistrationFunction : public FiniteDifferenceFunction<TDisplacementField>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalRegistrationFunction);
+  ITK_DISALLOW_COPY_AND_MOVE(VariationalRegistrationFunction);
 
   /** Standard class type alias. */
   using Self = VariationalRegistrationFunction;

--- a/include/itkVariationalRegistrationGaussianRegularizer.h
+++ b/include/itkVariationalRegistrationGaussianRegularizer.h
@@ -47,7 +47,7 @@ template <typename TDisplacementField>
 class VariationalRegistrationGaussianRegularizer : public VariationalRegistrationRegularizer<TDisplacementField>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalRegistrationGaussianRegularizer);
+  ITK_DISALLOW_COPY_AND_MOVE(VariationalRegistrationGaussianRegularizer);
 
   /** Standard class type alias */
   using Self = VariationalRegistrationGaussianRegularizer;

--- a/include/itkVariationalRegistrationLogger.h
+++ b/include/itkVariationalRegistrationLogger.h
@@ -47,7 +47,7 @@ template <typename TRegistrationFilter, typename TMRFilter>
 class VariationalRegistrationLogger : public Command
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalRegistrationLogger);
+  ITK_DISALLOW_COPY_AND_MOVE(VariationalRegistrationLogger);
 
   /** Standard class type alias. */
   using Self = VariationalRegistrationLogger;

--- a/include/itkVariationalRegistrationMultiResolutionFilter.h
+++ b/include/itkVariationalRegistrationMultiResolutionFilter.h
@@ -81,7 +81,7 @@ template <typename TFixedImage, typename TMovingImage, typename TDisplacementFie
 class VariationalRegistrationMultiResolutionFilter : public ImageToImageFilter<TDisplacementField, TDisplacementField>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalRegistrationMultiResolutionFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(VariationalRegistrationMultiResolutionFilter);
 
   /** Standard class type alias */
   using Self = VariationalRegistrationMultiResolutionFilter;

--- a/include/itkVariationalRegistrationNCCFunction.h
+++ b/include/itkVariationalRegistrationNCCFunction.h
@@ -66,7 +66,7 @@ class VariationalRegistrationNCCFunction
   : public VariationalRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalRegistrationNCCFunction);
+  ITK_DISALLOW_COPY_AND_MOVE(VariationalRegistrationNCCFunction);
 
   /** Standard class type alias. */
   using Self = VariationalRegistrationNCCFunction;

--- a/include/itkVariationalRegistrationRegularizer.h
+++ b/include/itkVariationalRegistrationRegularizer.h
@@ -47,7 +47,7 @@ template <typename TDisplacementField>
 class VariationalRegistrationRegularizer : public InPlaceImageFilter<TDisplacementField, TDisplacementField>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalRegistrationRegularizer);
+  ITK_DISALLOW_COPY_AND_MOVE(VariationalRegistrationRegularizer);
 
   /** Standard class type alias */
   using Self = VariationalRegistrationRegularizer;

--- a/include/itkVariationalRegistrationSSDFunction.h
+++ b/include/itkVariationalRegistrationSSDFunction.h
@@ -54,7 +54,7 @@ class VariationalRegistrationSSDFunction
   : public VariationalRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalRegistrationSSDFunction);
+  ITK_DISALLOW_COPY_AND_MOVE(VariationalRegistrationSSDFunction);
 
   /** Standard class type alias. */
   using Self = VariationalRegistrationSSDFunction;

--- a/include/itkVariationalRegistrationStopCriterion.h
+++ b/include/itkVariationalRegistrationStopCriterion.h
@@ -69,7 +69,7 @@ template <typename TRegistrationFilter, typename TMRFilter>
 class VariationalRegistrationStopCriterion : public Command
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalRegistrationStopCriterion);
+  ITK_DISALLOW_COPY_AND_MOVE(VariationalRegistrationStopCriterion);
 
   /** Standard class type alias. */
   using Self = VariationalRegistrationStopCriterion;

--- a/include/itkVariationalSymmetricDiffeomorphicRegistrationFilter.h
+++ b/include/itkVariationalSymmetricDiffeomorphicRegistrationFilter.h
@@ -92,7 +92,7 @@ class VariationalSymmetricDiffeomorphicRegistrationFilter
   : public VariationalDiffeomorphicRegistrationFilter<TFixedImage, TMovingImage, TDisplacementField>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(VariationalSymmetricDiffeomorphicRegistrationFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(VariationalSymmetricDiffeomorphicRegistrationFilter);
 
   /** Standard class type alias */
   using Self = VariationalSymmetricDiffeomorphicRegistrationFilter;


### PR DESCRIPTION
This PR fixes changes made in [#2053](https://github.com/InsightSoftwareConsortium/ITK/pull/2053/commits/4eac1a0cfb456fad1e3894173a41d7c7de49b08f). Essentially, `ITK_DISALLOW_COPY_AND_ASSIGN` has been changed to `ITK_DISALLOW_COPY_AND_MOVE` to more accurately convey the actions taking place. `ITK_DISALLOW_COPY_AND_ASSIGN` will **only** be used if `ITK_FUTURE_LEGACY_REMOVE=OFF`.

**NOTE:** These changes will cause the GitHub Actions to break, because they currently build `ITK v5.1.0`. The errors persist with `v5.1.1` as well (will update to newest version in separate PR). When tested locally against `master`, I get all tests to pass. The case is the same for the remaining 39 remote modules.